### PR TITLE
data2lib2: Fix build with newer GCCs

### DIFF
--- a/spectool/data2lib2.c
+++ b/spectool/data2lib2.c
@@ -114,7 +114,7 @@ static void OutputElementDefinition(const SpecElement **pElt, const SpecElement 
         nodetree* i;
         for (i = NodeTree_Children(elt); i; i = NodeTree_Next(i))
         {
-            OutputElementDefinition(&(SpecElement *)i, EltEnd, CFile, Extras);
+            OutputElementDefinition((SpecElement *)&i, EltEnd, CFile, Extras);
         }
     }
 


### PR DESCRIPTION
This is the same fix as d294a5e2801e560cd3bbb37951c95d5aff6c8bb0.