### PR TITLE
mkclean: Silence some bogus warnings

### DIFF
--- a/mkclean/mkclean.c
+++ b/mkclean/mkclean.c
@@ -182,7 +182,7 @@ static int CurrentPhase = 1;
 static bool_t MasterError(void *cookie, int type, const tchar_t *ClassName, const ebml_element *i)
 {
 	tchar_t IdString[MAXPATH];
-    if (type==MASTER_CHECK_PROFILE_INVALID)
+    if (type==MASTER_CHECK_PROFILE_INVALID && EBML_ElementPosition(i) != INVALID_FILEPOS_T)
     {
     	EBML_ElementGetName(i,IdString,TSIZEOF(IdString));
         TextPrintf(StdErr,T("The %s element at %") TPRId64 T(" is not part of profile '%s', skipping\r\n"),IdString,EBML_ElementPosition(i),GetProfileName(DstProfile));


### PR DESCRIPTION
Currently mandatory elements like `SeekPreRoll` that are physically absent in the input file and only assumed because they are mandatory frequently lead to bogus warnings like "The SeekPreRoll element at -1 is not part of profile 'matroska v2', skipping".

PS: There is actually another issue here: If one remuxes a version two file, the same warning appears, although `SeekPreRoll` is only compatible with Matroska v4 and Webm. For Matroska v1-v3 one shouldn't assume `SeekPreRoll` at all.