### PR TITLE
mkvalidator: Fix parsing of Video elements

### DIFF
--- a/mkvalidator/mkvalidator.c
+++ b/mkvalidator/mkvalidator.c
@@ -216,7 +216,7 @@ static int64_t gcd(int64_t a, int64_t b)
 static int CheckVideoTrack(ebml_master *Track, int TrackNum, int ProfileNum)
 {
 	int Result = 0;
-	ebml_element *Elt, *PixelW, *PixelH;
+	ebml_element *Elt;
 	ebml_integer *Unit;
 	ebml_master *Video;
 	Video = (ebml_master*)EBML_MasterFindChild(Track,&MATROSKA_ContextVideo);
@@ -225,91 +225,114 @@ static int CheckVideoTrack(ebml_master *Track, int TrackNum, int ProfileNum)
 	// check the DisplayWidth and DisplayHeight are correct
 	else
 	{
-		int64_t DisplayW = 0,DisplayH = 0;
-		PixelW = EBML_MasterGetChild(Video,&MATROSKA_ContextPixelWidth);
-		if (!PixelW)
+		int64_t DisplayW = 0, DisplayH = 0, PixelW = 0, PixelH = 0, OrPixelW, OrPixelH;
+		Elt = EBML_MasterGetChild(Video,&MATROSKA_ContextPixelWidth);
+		if (!Elt)
 			Result |= OutputError(0xE1,T("Video track #%d at %") TPRId64 T(" has no pixel width"),TrackNum,EL_Pos(Track));
-		PixelH = EBML_MasterGetChild(Video,&MATROSKA_ContextPixelHeight);
-		if (!PixelH)
+        else
+        {
+            PixelW = OrPixelW = EL_Int(Elt);
+            if (PixelW == 0)
+                Result |= OutputError(0xE1,T("Video track #%d at %") TPRId64 T(" has pixel width 0"), TrackNum,EL_Pos(Track));
+            else
+            {
+                int64_t CropL, CropR;
+                Elt   = EBML_MasterGetChild(Video,&MATROSKA_ContextPixelCropLeft);
+                CropL = EL_Int(Elt);
+                Elt   = EBML_MasterGetChild(Video,&MATROSKA_ContextPixelCropRight);
+                CropR = EL_Int(Elt);
+
+                if (CropL + CropR >= PixelW)
+                    Result |= OutputError(0xE6,T("Video track #%d is cropping too many horizontal pixels %") TPRId64 T(" vs %") TPRId64 T(" + %") TPRId64,TrackNum, PixelW, CropL, CropR);
+                else
+                    PixelW  -= CropL + CropR;
+            }
+        }
+
+        Elt = EBML_MasterGetChild(Video,&MATROSKA_ContextPixelHeight);
+		if (!Elt)
 			Result |= OutputError(0xE2,T("Video track #%d at %") TPRId64 T(" has no pixel height"),TrackNum,EL_Pos(Track));
+        else
+        {
+            PixelH = OrPixelH = EL_Int(Elt);
+            if (PixelH == 0)
+                Result |= OutputError(0xE2,T("Video track #%d at %") TPRId64 T(" has pixel height 0"), TrackNum,EL_Pos(Track));
+            else
+            {
+                int64_t CropT, CropB;
+                Elt   = EBML_MasterGetChild(Video,&MATROSKA_ContextPixelCropTop);
+                CropT = EL_Int(Elt);
+                Elt   = EBML_MasterGetChild(Video,&MATROSKA_ContextPixelCropBottom);
+                CropB = EL_Int(Elt);
+
+                if (CropT + CropB >= PixelH)
+                    Result |= OutputError(0xE5,T("Video track #%d is cropping too many vertical pixels %") TPRId64 T(" vs %") TPRId64 T(" + %") TPRId64,TrackNum, PixelH, CropT, CropB);
+                else
+                    PixelH  -= CropT + CropB;
+            }
+        }
 
         Unit = (ebml_integer*)EBML_MasterGetChild(Video,&MATROSKA_ContextDisplayUnit);
 		assert(Unit!=NULL);
 
 		Elt = EBML_MasterFindChild(Video,&MATROSKA_ContextDisplayWidth);
 		if (Elt)
+        {
 			DisplayW = EL_Int(Elt);
+
+            if (DisplayW == 0)
+                Result |= OutputError(0xE7,T("Video track #%d at %") TPRId64 T(" has a null display width"),TrackNum,EL_Pos(Track));
+        }
 		else if (EL_Int(Unit)!=MATROSKA_DISPLAY_UNIT_PIXEL)
-			Result |= OutputError(0xE2,T("Video track #%d at %") TPRId64 T(" has an implied non pixel width"),TrackNum,EL_Pos(Track));
+			Result |= OutputError(0xE1,T("Video track #%d at %") TPRId64 T(" has an implied non pixel width"),TrackNum,EL_Pos(Track));
         else if (PixelW)
-			DisplayW = EL_Int(PixelW);
+			DisplayW = PixelW;
 
 		Elt = EBML_MasterFindChild(Video,&MATROSKA_ContextDisplayHeight);
 		if (Elt)
+        {
 			DisplayH = EL_Int(Elt);
+
+            if (DisplayH == 0)
+                Result |= OutputError(0xE7,T("Video track #%d at %") TPRId64 T(" has a null display height"),TrackNum,EL_Pos(Track));
+        }
 		else if (EL_Int(Unit)!=MATROSKA_DISPLAY_UNIT_PIXEL)
 			Result |= OutputError(0xE2,T("Video track #%d at %") TPRId64 T(" has an implied non pixel height"),TrackNum,EL_Pos(Track));
 		else if (PixelH)
-			DisplayH = EL_Int(PixelH);
+			DisplayH = PixelH;
 
-		if (DisplayH==0)
-			Result |= OutputError(0xE7,T("Video track #%d at %") TPRId64 T(" has a null display height"),TrackNum,EL_Pos(Track));
-		if (DisplayW==0)
-			Result |= OutputError(0xE7,T("Video track #%d at %") TPRId64 T(" has a null display width"),TrackNum,EL_Pos(Track));
-
-		if (EL_Int(Unit)==MATROSKA_DISPLAY_UNIT_PIXEL && PixelW && PixelH)
+		if (EL_Int(Unit)==MATROSKA_DISPLAY_UNIT_PIXEL && PixelW && PixelH && DisplayH && DisplayW)
 		{
 			// check if the pixel sizes appear valid
-			if (DisplayW < EL_Int(PixelW) && DisplayH < EL_Int(PixelH))
+			if (DisplayW < PixelW && DisplayH < PixelH)
 			{
                 int Serious = gcd(DisplayW,DisplayH)==1; // the DAR values were reduced as much as possible
-                if (DisplayW*EL_Int(PixelH) == DisplayH*EL_Int(PixelW))
+                if (DisplayW * PixelH == DisplayH * PixelW)
                     Serious++; // same aspect ratio as the source
-                if (8*DisplayW <= EL_Int(PixelW) && 8*DisplayH <= EL_Int(PixelH))
+                if (8 * DisplayW <= PixelW && 8 * DisplayH <= PixelH)
                     Serious+=2; // too much shrinking compared to the original pixels
                 if (ProfileNum!=PROFILE_WEBM)
                     --Serious; // in Matroska it's tolerated as it's been operating like that for a while
 
 				if (Serious>2)
-					Result |= OutputError(0xE3,T("The output pixels for Video track #%d seem wrong %") TPRId64 T("x%") TPRId64 T("px from %") TPRId64 T("x%") TPRId64,TrackNum,DisplayW,DisplayH,EL_Int(PixelW),EL_Int(PixelH));
+					Result |= OutputError(0xE3,T("The output pixels for Video track #%d seem wrong %") TPRId64 T("x%") TPRId64 T("px from %") TPRId64 T("x%") TPRId64,TrackNum,DisplayW,DisplayH,PixelW,PixelH);
 				else if (Serious)
-					OutputWarning(0xE3,T("The output pixels for Video track #%d seem wrong %") TPRId64 T("x%") TPRId64 T("px from %") TPRId64 T("x%") TPRId64,TrackNum,DisplayW,DisplayH,EL_Int(PixelW),EL_Int(PixelH));
+					OutputWarning(0xE3,T("The output pixels for Video track #%d seem wrong %") TPRId64 T("x%") TPRId64 T("px from %") TPRId64 T("x%") TPRId64,TrackNum,DisplayW,DisplayH,PixelW,PixelH);
 			}
+            else if ((OrPixelH != PixelH || OrPixelW != PixelW) && PixelH && PixelW && (OrPixelH == DisplayH) && (OrPixelW == DisplayW))
+                // The DisplayW/H elements apply to the frames after cropping so that if one adds cropping values,
+                // one often has to adapt the display dimensions if one wants to keep the pixel aspect ratio.
+                // This check here tests whether this has been forgotten. The check only works for non-anamorphic content;
+                // there might be some false positives for anamorphic content.
+                OutputWarning(0xE4,T("It seems that the display dimensions of Video track #%d have not been adapted in light of the use of cropping: The display dimensions coincide with the pre-cropping pixel dimensions."), TrackNum);
 		}
 
         if (EL_Int(Unit)==MATROSKA_DISPLAY_UNIT_DAR)
         {
-            // crop values should never exist
-            Elt = EBML_MasterFindChild(Video,&MATROSKA_ContextPixelCropTop);
-            if (Elt)
-                Result |= OutputError(0xE4,T("Video track #%d is using unconstrained aspect ratio and has top crop at %") TPRId64,TrackNum,EL_Pos(Elt));
-            Elt = EBML_MasterFindChild(Video,&MATROSKA_ContextPixelCropBottom);
-            if (Elt)
-                Result |= OutputError(0xE4,T("Video track #%d is using unconstrained aspect ratio and has bottom crop at %") TPRId64,TrackNum,EL_Pos(Elt));
-            Elt = EBML_MasterFindChild(Video,&MATROSKA_ContextPixelCropLeft);
-            if (Elt)
-                Result |= OutputError(0xE4,T("Video track #%d is using unconstrained aspect ratio and has left crop at %") TPRId64,TrackNum,EL_Pos(Elt));
-            Elt = EBML_MasterFindChild(Video,&MATROSKA_ContextPixelCropRight);
-            if (Elt)
-                Result |= OutputError(0xE4,T("Video track #%d is using unconstrained aspect ratio and has right crop at %") TPRId64,TrackNum,EL_Pos(Elt));
-
-			if (PixelW && DisplayW == EL_Int(PixelW))
-				OutputWarning(0xE7,T("DisplayUnit seems to be pixels not aspect-ratio for Video track #%d %") TPRId64 T("px width from %") TPRId64,TrackNum,DisplayW,EL_Int(PixelW));
-			if (PixelH && DisplayH == EL_Int(PixelH))
-				OutputWarning(0xE7,T("DisplayUnit seems to be pixels not aspect-ratio for Video track #%d %") TPRId64 T("px height from %") TPRId64,TrackNum,DisplayH,EL_Int(PixelH));
-        }
-        else
-        {
-            // crop values should be less than the extended value
-            PixelW = EBML_MasterGetChild(Video,&MATROSKA_ContextPixelCropTop);
-            PixelH = EBML_MasterGetChild(Video,&MATROSKA_ContextPixelCropBottom);
-            if (EL_Int(PixelW) + EL_Int(PixelH) >= DisplayH)
-                Result |= OutputError(0xE5,T("Video track #%d is cropping too many vertical pixels %") TPRId64 T(" vs %") TPRId64 T(" + %") TPRId64,TrackNum, DisplayH, EL_Int(PixelW), EL_Int(PixelH));
-
-            PixelW = EBML_MasterGetChild(Video,&MATROSKA_ContextPixelCropLeft);
-            PixelH = EBML_MasterGetChild(Video,&MATROSKA_ContextPixelCropRight);
-            if (EL_Int(PixelW) + EL_Int(PixelH) >= DisplayW)
-                Result |= OutputError(0xE6,T("Video track #%d is cropping too many horizontal pixels %") TPRId64 T(" vs %") TPRId64 T(" + %") TPRId64,TrackNum, DisplayW, EL_Int(PixelW), EL_Int(PixelH));
+			if (PixelW && PixelW == DisplayW)
+				OutputWarning(0xE7,T("DisplayUnit seems to be pixels not aspect-ratio for Video track #%d %") TPRId64 T("px width from %") TPRId64,TrackNum,DisplayW,PixelW);
+			if (PixelH && PixelH == DisplayH)
+				OutputWarning(0xE7,T("DisplayUnit seems to be pixels not aspect-ratio for Video track #%d %") TPRId64 T("px height from %") TPRId64,TrackNum,DisplayH,PixelH);
         }
 	}
 	return Result;


### PR DESCRIPTION
The earlier code checked the PixelCrop* elements as if they applied after the scaling to DisplayWidth/Height has been done.

Furthermore some checks have been improved (the earlier code didn't check whether PixelWidth/Height is zero). Moreover a heuristic check has been added to test whether it has been forgotten to update DisplayWidth/Height in light of the PixelCrop* elements.

I tried to preserve the error codes as much as possible; after all, they may be used in scripts.