### PR TITLE
use _strdup instead of strdup with MSVC

### DIFF
--- a/corec/corec/portab.h
+++ b/corec/corec/portab.h
@@ -180,6 +180,7 @@
 #ifndef strnicmp
 #define strnicmp(x,y,z)    _strnicmp(x,y,z)
 #endif
+#define strdup(x)          _strdup(x)
 
 #ifndef alloca
 #define alloca _alloca


### PR DESCRIPTION
strXXX is supposed to be reserved in ISO C but POSIX just uses that word.
MSVC (and its clang friend) doesn't like it.