### PR TITLE
Fix cygwin linking

### DIFF
--- a/corec/corec/helpers/CMakeLists.txt
+++ b/corec/corec/helpers/CMakeLists.txt
@@ -61,6 +61,10 @@ set(corec_parser_PUBLIC_HEADERS
 add_library("corec_parser" INTERFACE)
 target_sources("corec_parser" INTERFACE ${corec_parser_SOURCES} ${corec_parser_PUBLIC_HEADERS})
 target_link_libraries("corec_parser" INTERFACE "corec_str" "corec_charconvert" "corec_file")
+if (CYGWIN)
+# if CMake wasn't this piece of shit this would simply work
+  target_link_libraries("corec_parser" INTERFACE iconv)
+endif (CYGWIN)
 target_include_directories("corec_parser" INTERFACE ".")
 
 # System call API
@@ -141,5 +145,8 @@ elseif(UNIX)
   target_sources("corec_charconvert" INTERFACE ${corec_charconvert_LINUX_SOURCES})
 else(UNIX)
   target_sources("corec_charconvert" INTERFACE ${corec_charconvert_OTHER_SOURCES})
+  if (CYGWIN)
+    target_link_libraries("corec_charconvert" INTERFACE iconv)
+  endif (CYGWIN)
 endif(WIN32)
 target_link_libraries("corec_charconvert" INTERFACE "corec_bare")

--- a/corec/corec/helpers/charconvert/charconvert_linux.c
+++ b/corec/corec/helpers/charconvert/charconvert_linux.c
@@ -38,7 +38,7 @@
 #include <errno.h>
 
 #ifndef ICONV_CONST
-#if defined(__GLIBC__)
+#if defined(__GLIBC__) || defined(__CYGWIN__)
 #define ICONV_CONST
 #else
 #define ICONV_CONST const

--- a/corec/tests/CMakeLists.txt
+++ b/corec/tests/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_executable("string_test" string_test.c)
 target_link_libraries("string_test" PUBLIC "corec_str" "corec_charconvert")
+if (CYGWIN)
+# if CMake wasn't this piece of shit this would simply work
+  target_link_libraries("string_test" PRIVATE iconv)
+endif (CYGWIN)
 
 add_executable("file_test" file_test.c)
 target_link_libraries("file_test" PUBLIC "corec_file")


### PR DESCRIPTION
CMake being CMake, it's not possible to propagate iconv linking through the INTERFACE `target_link_libraries`. It has to be set on all real libraries using the INTERFACE directly or indirectly.

Fixes #72