### PR TITLE
Make tighter use of profiles when reading/writing

### DIFF
--- a/corec/corec/helper.h
+++ b/corec/corec/helper.h
@@ -255,31 +255,6 @@ typedef int32_t datetime_t;
 #define MIN_DATETIME_T  ((datetime_t) 0xFFFFFFFF)
 #define MAX_DATETIME_T  ((datetime_t) 0x7FFFFFFF)
 
-static INLINE int Fix16Mul(int a,int b)
-{
-    return (int)(((int64_t)(a<<8)*(int64_t)(b<<8))>>32);
-}
-
-static INLINE uint32_t _ones(uint32_t x)
-{
-    x -= ((x >> 1) & 0x55555555);
-    x = (((x >> 2) & 0x33333333) + (x & 0x33333333));
-    x = (((x >> 4) + x) & 0x0f0f0f0f);
-    x += (x >> 8);
-    x += (x >> 16);
-    return x & 0x0000003f;
-}
-
-static INLINE uint32_t _floor_log2(uint32_t x)
-{
-    x |= (x >> 1);
-    x |= (x >> 2);
-    x |= (x >> 4);
-    x |= (x >> 8);
-    x |= (x >> 16);
-    return _ones(x) - 1;
-}
-
 #if !defined(min) && !defined(NOMINMAX)
 #  define min(x,y)  ((x)>(y)?(y):(x))
 #endif

--- a/corec/corec/portab.h
+++ b/corec/corec/portab.h
@@ -180,7 +180,9 @@
 #ifndef strnicmp
 #define strnicmp(x,y,z)    _strnicmp(x,y,z)
 #endif
+#ifndef strdup
 #define strdup(x)          _strdup(x)
+#endif
 
 #ifndef alloca
 #define alloca _alloca

--- a/libebml2/ebmlbinary.c
+++ b/libebml2/ebmlbinary.c
@@ -57,7 +57,7 @@ failed:
 }
 
 #if defined(CONFIG_EBML_WRITING)
-static err_t RenderData(ebml_binary *Element, stream *Output, bool_t bForceWithoutMandatory, bool_t bWithDefault, filepos_t *Rendered)
+static err_t RenderData(ebml_binary *Element, stream *Output, bool_t bForceWithoutMandatory, bool_t bWithDefault, int ForProfile, filepos_t *Rendered)
 {
     size_t Written;
     err_t Err = Stream_Write(Output,ARRAYBEGIN(Element->Data,uint8_t),ARRAYCOUNT(Element->Data,uint8_t),&Written);
@@ -77,11 +77,11 @@ static bool_t IsDefaultValue(const ebml_binary *Element)
     return 0; // TODO: a default binary value needs a size too (use a structure to set the value in the structure)
 }
 
-static filepos_t UpdateDataSize(ebml_binary *Element, bool_t bWithDefault, bool_t bForceWithoutMandatory)
+static filepos_t UpdateDataSize(ebml_binary *Element, bool_t bWithDefault, bool_t bForceWithoutMandatory, int ForProfile)
 {
 	Element->Base.DataSize = ARRAYCOUNT(Element->Data,uint8_t);
 
-	return INHERITED(Element,ebml_element_vmt,EBML_BINARY_CLASS)->UpdateDataSize(Element, bWithDefault, bForceWithoutMandatory);
+	return INHERITED(Element,ebml_element_vmt,EBML_BINARY_CLASS)->UpdateDataSize(Element, bWithDefault, bForceWithoutMandatory, ForProfile);
 }
 
 static bool_t ValidateSize(const ebml_element *p)
@@ -91,7 +91,7 @@ static bool_t ValidateSize(const ebml_element *p)
 
 static ebml_binary *Copy(const ebml_binary *Element, const void *Cookie)
 {
-    ebml_binary *Result = (ebml_binary*)EBML_ElementCreate(Element,Element->Base.Context,0,Cookie);
+    ebml_binary *Result = (ebml_binary*)EBML_ElementCreate(Element,Element->Base.Context,0,EBML_ANY_PROFILE,Cookie);
     if (Result)
     {
         ArrayCopy(&Result->Data,&Element->Data);

--- a/libebml2/ebmlcrc.c
+++ b/libebml2/ebmlcrc.c
@@ -174,7 +174,7 @@ static err_t ReadData(ebml_crc *Element, stream *Input, const ebml_parser_contex
 }
 
 #if defined(CONFIG_EBML_WRITING)
-static err_t RenderData(ebml_crc *Element, stream *Output, bool_t bForceWithoutMandatory, bool_t bWithDefault, filepos_t *Rendered)
+static err_t RenderData(ebml_crc *Element, stream *Output, bool_t bForceWithoutMandatory, bool_t bWithDefault, int ForProfile, filepos_t *Rendered)
 {
     err_t Result;
     size_t Written = 0;
@@ -189,7 +189,7 @@ static err_t RenderData(ebml_crc *Element, stream *Output, bool_t bForceWithoutM
 
 static ebml_crc *Copy(const ebml_crc *Element, const void *Cookie)
 {
-    ebml_crc *Result = (ebml_crc*)EBML_ElementCreate(Element,Element->Base.Context,0,Cookie);
+    ebml_crc *Result = (ebml_crc*)EBML_ElementCreate(Element,Element->Base.Context,0,EBML_ANY_PROFILE,Cookie);
     if (Result)
     {
         Result->CRC = Element->CRC;

--- a/libebml2/ebmldate.c
+++ b/libebml2/ebmldate.c
@@ -89,9 +89,9 @@ failed:
     return Result;
 }
 
-static void PostCreate(ebml_date *Element, bool_t SetDefault)
+static void PostCreate(ebml_date *Element, bool_t SetDefault, int ForProfile)
 {
-    INHERITED(Element,ebml_element_vmt,EBML_DATE_CLASS)->PostCreate(Element, SetDefault);
+    INHERITED(Element,ebml_element_vmt,EBML_DATE_CLASS)->PostCreate(Element, SetDefault, ForProfile);
     Element->Base.DefaultSize = 8;
     Element->Base.bNeedDataSizeUpdate = 0;
 }

--- a/libebml2/ebmlelement.c
+++ b/libebml2/ebmlelement.c
@@ -33,7 +33,7 @@ static bool_t ValidateSize(const ebml_element *p)
     return EBML_ElementIsFiniteSize(p); /* not allowed outside of master elements */
 }
 
-static void PostCreate(ebml_element *Element, bool_t SetDefault)
+static void PostCreate(ebml_element *Element, bool_t SetDefault, int ForProfile)
 {
     Element->DefaultSize = -1;
     Element->ElementPosition = INVALID_FILEPOS_T;
@@ -50,7 +50,7 @@ static bool_t NeedsDataSizeUpdate(ebml_element *Element, bool_t bWithDefault)
     return 1;
 }
 
-static filepos_t UpdateDataSize(ebml_element *Element, bool_t bWithDefault, bool_t bForceWithoutMandatory)
+static filepos_t UpdateDataSize(ebml_element *Element, bool_t bWithDefault, bool_t bForceWithoutMandatory, int ForProfile)
 {
 	if (!bWithDefault && EBML_ElementIsDefaultValue(Element))
 		return 0;
@@ -275,7 +275,7 @@ fourcc_t EBML_BufferToID(const uint8_t *Buffer)
 }
 
 #if defined(CONFIG_EBML_WRITING)
-err_t EBML_ElementRender(ebml_element *Element, stream *Output, bool_t bWithDefault, bool_t bKeepPosition, bool_t bForceWithoutMandatory, filepos_t *Rendered)
+err_t EBML_ElementRender(ebml_element *Element, stream *Output, bool_t bWithDefault, bool_t bKeepPosition, bool_t bForceWithoutMandatory, int ForProfile, filepos_t *Rendered)
 {
     err_t Result;
     filepos_t _Rendered,WrittenSize;
@@ -298,19 +298,19 @@ err_t EBML_ElementRender(ebml_element *Element, stream *Output, bool_t bWithDefa
 
 #if !defined(NDEBUG)
     if (EBML_ElementNeedsDataSizeUpdate(Element, bWithDefault))
-	    SupposedSize = EBML_ElementUpdateSize(Element, bWithDefault, bForceWithoutMandatory);
+	    SupposedSize = EBML_ElementUpdateSize(Element, bWithDefault, bForceWithoutMandatory, ForProfile);
     else
         SupposedSize = Element->DataSize;
 #else
     if (EBML_ElementNeedsDataSizeUpdate(Element, bWithDefault))
-	    EBML_ElementUpdateSize(Element, bWithDefault, bForceWithoutMandatory);
+	    EBML_ElementUpdateSize(Element, bWithDefault, bForceWithoutMandatory, ForProfile);
 #endif
 	Result = EBML_ElementRenderHead(Element, Output, bKeepPosition, &WrittenSize);
     *Rendered += WrittenSize;
     if (Result != ERR_NONE)
         return Result;
 
-    Result = EBML_ElementRenderData(Element, Output, bForceWithoutMandatory, bWithDefault, &WrittenSize);
+    Result = EBML_ElementRenderData(Element, Output, bForceWithoutMandatory, bWithDefault, ForProfile, &WrittenSize);
 #if !defined(NDEBUG)
     if (SupposedSize != INVALID_FILEPOS_T) assert(WrittenSize == SupposedSize);
 #endif

--- a/libebml2/ebmlmain.c
+++ b/libebml2/ebmlmain.c
@@ -334,14 +334,14 @@ static ebml_element *EBML_ElementCreateUsingContext(void *AnyNode, const uint8_t
 ebml_element *EBML_FindNextId(stream *Input, const ebml_context *Context, size_t MaxDataSize)
 {
     filepos_t aElementPosition, aSizePosition;
-    filepos_t SizeFound=0, SizeUnknown;
+    filepos_t SizeFound=0, SizeUnknown=8;
     int ReadSize;
     uint8_t BitMask;
     uint8_t PossibleId[4];
     uint8_t PossibleSize[8]; // we don't support size stored in more than 64 bits
     bool_t bElementFound = 0;
     int8_t PossibleID_Length = 0;
-    size_t _SizeLength;
+    size_t _SizeLength=0;
     uint8_t PossibleSizeLength = 0;
     ebml_element *Result = NULL;
 

--- a/libebml2/ebmlnumber.c
+++ b/libebml2/ebmlnumber.c
@@ -110,7 +110,7 @@ failed:
 }
 
 #if defined(CONFIG_EBML_WRITING)
-static err_t RenderDataSignedInt(ebml_integer *Element, stream *Output, bool_t bForceWithoutMandatory, bool_t bWithDefault, filepos_t *Rendered)
+static err_t RenderDataSignedInt(ebml_integer *Element, stream *Output, bool_t bForceWithoutMandatory, bool_t bWithDefault, int ForProfile, filepos_t *Rendered)
 {
 	uint8_t FinalData[8]; // we don't handle more than 64 bits integers
 	size_t i;
@@ -146,7 +146,7 @@ static err_t RenderDataSignedInt(ebml_integer *Element, stream *Output, bool_t b
     return Err;
 }
 
-static err_t RenderDataInt(ebml_integer *Element, stream *Output, bool_t bForceWithoutMandatory, bool_t bWithDefault, filepos_t *Rendered)
+static err_t RenderDataInt(ebml_integer *Element, stream *Output, bool_t bForceWithoutMandatory, bool_t bWithDefault, int ForProfile, filepos_t *Rendered)
 {
 	uint8_t FinalData[8]; // we don't handle more than 64 bits integers
 	size_t i;
@@ -182,7 +182,7 @@ static err_t RenderDataInt(ebml_integer *Element, stream *Output, bool_t bForceW
     return Err;
 }
 
-static err_t RenderDataFloat(ebml_float *Element, stream *Output, bool_t bForceWithoutMandatory, bool_t bWithDefault, filepos_t *Rendered)
+static err_t RenderDataFloat(ebml_float *Element, stream *Output, bool_t bForceWithoutMandatory, bool_t bWithDefault, int ForProfile, filepos_t *Rendered)
 {
     err_t Err;
 	size_t i = 0;
@@ -283,7 +283,7 @@ static bool_t IsDefaultValueFloat(const ebml_float *Element)
     return Element->Base.Context->HasDefault && (!Element->Base.bValueIsSet || (Element->Value == (double)Element->Base.Context->DefaultValue));
 }
 
-static filepos_t UpdateSizeSignedInt(ebml_integer *Element, bool_t bWithDefault, bool_t bForceWithoutMandatory)
+static filepos_t UpdateSizeSignedInt(ebml_integer *Element, bool_t bWithDefault, bool_t bForceWithoutMandatory, int ForProfile)
 {
     if (EBML_ElementNeedsDataSizeUpdate(Element, bWithDefault))
     {
@@ -305,10 +305,10 @@ static filepos_t UpdateSizeSignedInt(ebml_integer *Element, bool_t bWithDefault,
 		    Element->Base.DataSize = 8;
     }
 
-	return INHERITED(Element,ebml_element_vmt,EBML_SINTEGER_CLASS)->UpdateDataSize(Element, bWithDefault, bForceWithoutMandatory);
+	return INHERITED(Element,ebml_element_vmt,EBML_SINTEGER_CLASS)->UpdateDataSize(Element, bWithDefault, bForceWithoutMandatory, ForProfile);
 }
 
-static filepos_t UpdateSizeInt(ebml_integer *Element, bool_t bWithDefault, bool_t bForceWithoutMandatory)
+static filepos_t UpdateSizeInt(ebml_integer *Element, bool_t bWithDefault, bool_t bForceWithoutMandatory, int ForProfile)
 {
     if (EBML_ElementNeedsDataSizeUpdate(Element, bWithDefault))
     {
@@ -330,28 +330,28 @@ static filepos_t UpdateSizeInt(ebml_integer *Element, bool_t bWithDefault, bool_
 		    Element->Base.DataSize = 8;
     }
 
-	return INHERITED(Element,ebml_element_vmt,EBML_INTEGER_CLASS)->UpdateDataSize(Element, bWithDefault, bForceWithoutMandatory);
+	return INHERITED(Element,ebml_element_vmt,EBML_INTEGER_CLASS)->UpdateDataSize(Element, bWithDefault, bForceWithoutMandatory, ForProfile);
 }
 
-static void PostCreateInt(ebml_element *Element, bool_t SetDefault)
+static void PostCreateInt(ebml_element *Element, bool_t SetDefault, int ForProfile)
 {
-    INHERITED(Element,ebml_element_vmt,EBML_INTEGER_CLASS)->PostCreate(Element, SetDefault);
+    INHERITED(Element,ebml_element_vmt,EBML_INTEGER_CLASS)->PostCreate(Element, SetDefault, ForProfile);
     Element->DefaultSize = 1;
     if (SetDefault && Element->Context->HasDefault)
         EBML_IntegerSetValue((ebml_integer*)Element, Element->Context->DefaultValue);
 }
 
-static void PostCreateSignedInt(ebml_element *Element, bool_t SetDefault)
+static void PostCreateSignedInt(ebml_element *Element, bool_t SetDefault, int ForProfile)
 {
-    INHERITED(Element,ebml_element_vmt,EBML_SINTEGER_CLASS)->PostCreate(Element, SetDefault);
+    INHERITED(Element,ebml_element_vmt,EBML_SINTEGER_CLASS)->PostCreate(Element, SetDefault, ForProfile);
     Element->DefaultSize = 1;
     if (SetDefault && Element->Context->HasDefault)
         EBML_IntegerSetValue((ebml_integer*)Element, Element->Context->DefaultValue);
 }
 
-static void PostCreateFloat(ebml_element *Element, bool_t SetDefault)
+static void PostCreateFloat(ebml_element *Element, bool_t SetDefault, int ForProfile)
 {
-    INHERITED(Element,ebml_element_vmt,EBML_FLOAT_CLASS)->PostCreate(Element, SetDefault);
+    INHERITED(Element,ebml_element_vmt,EBML_FLOAT_CLASS)->PostCreate(Element, SetDefault, ForProfile);
     Element->DefaultSize = 4;
     if (SetDefault && Element->Context->HasDefault)
         EBML_FloatSetValue((ebml_float*)Element, Element->Context->DefaultValue);
@@ -359,7 +359,7 @@ static void PostCreateFloat(ebml_element *Element, bool_t SetDefault)
 
 static ebml_integer *CopyInt(const ebml_integer *Element, const void *Cookie)
 {
-    ebml_integer *Result = (ebml_integer*)EBML_ElementCreate(Element,Element->Base.Context,0,Cookie);
+    ebml_integer *Result = (ebml_integer*)EBML_ElementCreate(Element,Element->Base.Context,0,EBML_ANY_PROFILE,Cookie);
     if (Result)
     {
         Result->Value = Element->Value;
@@ -376,7 +376,7 @@ static ebml_integer *CopyInt(const ebml_integer *Element, const void *Cookie)
 
 static ebml_float *CopyFloat(const ebml_float *Element, const void *Cookie)
 {
-    ebml_float *Result = (ebml_float*)EBML_ElementCreate(Element,Element->Base.Context,0,Cookie);
+    ebml_float *Result = (ebml_float*)EBML_ElementCreate(Element,Element->Base.Context,0,EBML_ANY_PROFILE,Cookie);
     if (Result)
     {
         Result->Value = Element->Value;

--- a/libebml2/ebmlstring.c
+++ b/libebml2/ebmlstring.c
@@ -106,7 +106,7 @@ failed:
 }
 
 #if defined(CONFIG_EBML_WRITING)
-static err_t RenderData(ebml_string *Element, stream *Output, bool_t bForceWithoutMandatory, bool_t bWithDefault, filepos_t *Rendered)
+static err_t RenderData(ebml_string *Element, stream *Output, bool_t bForceWithoutMandatory, bool_t bWithDefault, int ForProfile, filepos_t *Rendered)
 {
     size_t Written;
     err_t Err = Stream_Write(Output,Element->Buffer,(size_t)Element->Base.DataSize,&Written);
@@ -163,20 +163,20 @@ static void Delete(ebml_string *p)
         free((char*)p->Buffer);
 }
 
-static filepos_t UpdateDataSize(ebml_string *Element, bool_t bWithDefault, bool_t bForceWithoutMandatory)
+static filepos_t UpdateDataSize(ebml_string *Element, bool_t bWithDefault, bool_t bForceWithoutMandatory, int ForProfile)
 {
     if (EBML_ElementNeedsDataSizeUpdate(Element, bWithDefault))
         Element->Base.DataSize = strlen(Element->Buffer);
 
-	return INHERITED(Element,ebml_element_vmt,EBML_STRING_CLASS)->UpdateDataSize(Element, bWithDefault, bForceWithoutMandatory);
+	return INHERITED(Element,ebml_element_vmt,EBML_STRING_CLASS)->UpdateDataSize(Element, bWithDefault, bForceWithoutMandatory, ForProfile);
 }
 
-static filepos_t UpdateDataSizeUni(ebml_string *Element, bool_t bWithDefault, bool_t bForceWithoutMandatory)
+static filepos_t UpdateDataSizeUni(ebml_string *Element, bool_t bWithDefault, bool_t bForceWithoutMandatory, int ForProfile)
 {
     if (EBML_ElementNeedsDataSizeUpdate(Element, bWithDefault))
         Element->Base.DataSize = strlen(Element->Buffer);
 
-	return INHERITED(Element,ebml_element_vmt,EBML_UNISTRING_CLASS)->UpdateDataSize(Element, bWithDefault, bForceWithoutMandatory);
+	return INHERITED(Element,ebml_element_vmt,EBML_UNISTRING_CLASS)->UpdateDataSize(Element, bWithDefault, bForceWithoutMandatory, ForProfile);
 }
 
 static bool_t IsDefaultValue(const ebml_string *Element)
@@ -184,23 +184,23 @@ static bool_t IsDefaultValue(const ebml_string *Element)
     return Element->Base.Context->HasDefault && (!Element->Base.bValueIsSet || strcmp(Element->Buffer,(const char*)Element->Base.Context->DefaultValue)==0);
 }
 
-static void PostCreateString(ebml_element *Element, bool_t SetDefault)
+static void PostCreateString(ebml_element *Element, bool_t SetDefault, int ForProfile)
 {
-    INHERITED(Element,ebml_element_vmt,EBML_STRING_CLASS)->PostCreate(Element, SetDefault);
+    INHERITED(Element,ebml_element_vmt,EBML_STRING_CLASS)->PostCreate(Element, SetDefault, ForProfile);
     if (SetDefault && Element->Context->HasDefault)
         EBML_StringSetValue((ebml_string*)Element, (const char *)Element->Context->DefaultValue);
 }
 
-static void PostCreateUniString(ebml_element *Element, bool_t SetDefault)
+static void PostCreateUniString(ebml_element *Element, bool_t SetDefault, int ForProfile)
 {
-    INHERITED(Element,ebml_element_vmt,EBML_UNISTRING_CLASS)->PostCreate(Element, SetDefault);
+    INHERITED(Element,ebml_element_vmt,EBML_UNISTRING_CLASS)->PostCreate(Element, SetDefault, ForProfile);
     if (SetDefault && Element->Context->HasDefault)
         EBML_StringSetValue((ebml_string*)Element, (const char *)Element->Context->DefaultValue);
 }
 
 static ebml_string *Copy(const ebml_string *Element, const void *Cookie)
 {
-    ebml_string *Result = (ebml_string*)EBML_ElementCreate(Element,Element->Base.Context,0,Cookie);
+    ebml_string *Result = (ebml_string*)EBML_ElementCreate(Element,Element->Base.Context,0,EBML_ANY_PROFILE,Cookie);
     if (Result)
     {
         Result->Buffer = strdup(Element->Buffer);

--- a/libebml2/ebmlvoid.c
+++ b/libebml2/ebmlvoid.c
@@ -40,7 +40,7 @@ static err_t ReadData(ebml_element *Element, stream *Input, const ebml_parser_co
 }
 
 #if defined(CONFIG_EBML_WRITING)
-static err_t RenderData(ebml_element *Element, stream *Output, bool_t bForceWithoutMandatory, bool_t bWithDefault, filepos_t *Rendered)
+static err_t RenderData(ebml_element *Element, stream *Output, bool_t bForceWithoutMandatory, bool_t bWithDefault, int ForProfile, filepos_t *Rendered)
 {
     size_t Written, Left = (size_t)Element->DataSize;
     err_t Err = ERR_NONE;
@@ -60,7 +60,7 @@ static err_t RenderData(ebml_element *Element, stream *Output, bool_t bForceWith
 
 static ebml_element *Copy(const ebml_element *Element, const void *Cookie)
 {
-    ebml_element *Result = EBML_ElementCreate(Element,Element->Context,0,Cookie);
+    ebml_element *Result = EBML_ElementCreate(Element,Element->Context,0,EBML_ANY_PROFILE,Cookie);
     if (Result)
     {
         Result->bValueIsSet = Element->bValueIsSet;
@@ -98,7 +98,7 @@ filepos_t EBML_VoidReplaceWith(ebml_element *Void, ebml_element *ReplacedWith, s
     filepos_t CurrentPosition;
     assert(Node_IsPartOf(Void,EBML_VOID_CLASS));
 
-	EBML_ElementUpdateSize(ReplacedWith,bWithDefault,0);
+	EBML_ElementUpdateSize(ReplacedWith,bWithDefault,0, EBML_ANY_PROFILE);
 	if (EBML_ElementFullSize(Void,1) < EBML_ElementFullSize(ReplacedWith,1))
 		// the element can't be written here !
 		return INVALID_FILEPOS_T;
@@ -109,12 +109,12 @@ filepos_t EBML_VoidReplaceWith(ebml_element *Void, ebml_element *ReplacedWith, s
 	CurrentPosition = Stream_Seek(Output,0,SEEK_CUR);
 
     Stream_Seek(Output,Void->ElementPosition,SEEK_SET);
-    EBML_ElementRender(ReplacedWith,Output,bWithDefault,0,1,NULL);
+    EBML_ElementRender(ReplacedWith,Output,bWithDefault,0,1,EBML_ANY_PROFILE,NULL);
 
     if (EBML_ElementFullSize(Void,1) - EBML_ElementFullSize(ReplacedWith,1) > 1)
     {
         // fill the rest with another void element
-        ebml_element *aTmp = EBML_ElementCreate(Void,Void->Context,0,NULL);
+        ebml_element *aTmp = EBML_ElementCreate(Void,Void->Context,0,EBML_ANY_PROFILE,NULL);
         if (aTmp)
         {
             filepos_t HeadBefore,HeadAfter;

--- a/libebml2/test/ebmltree.c
+++ b/libebml2/test/ebmltree.c
@@ -160,7 +160,7 @@ static ebml_element *OutputElement(ebml_element *Element, const ebml_parser_cont
 
 static void OutputTree(stream *Input)
 {
-    ebml_element *Element = EBML_ElementCreate(Input,EBML_getContextHead(),0,NULL);
+    ebml_element *Element = EBML_ElementCreate(Input,EBML_getContextHead(),0, EBML_ANY_PROFILE,NULL);
     if (Element)
     {
         int Level = -1;

--- a/libmatroska2/matroska2/matroska.h
+++ b/libmatroska2/matroska2/matroska.h
@@ -48,6 +48,8 @@
 #define PROFILE_MATROSKA_V4          32
 #define PROFILE_WEBM                 8
 #define PROFILE_DIVX                16
+#define PROFILE_MATROSKA_ALL        (PROFILE_MATROSKA_V1|PROFILE_MATROSKA_V2|PROFILE_MATROSKA_V3|PROFILE_MATROSKA_V4) 
+#define PROFILE_MATROSKA_ANY        (PROFILE_MATROSKA_ALL|PROFILE_WEBM|PROFILE_DIVX) 
 
 #define MATROSKA_VERSION  2
 
@@ -124,19 +126,19 @@ typedef struct matroska_frame
 MATROSKA_DLL err_t MATROSKA_LinkMetaSeekElement(matroska_seekpoint *MetaSeek, ebml_element *Link);
 MATROSKA_DLL err_t MATROSKA_MetaSeekUpdate(matroska_seekpoint *MetaSeek);
 MATROSKA_DLL err_t MATROSKA_LinkClusterReadSegmentInfo(matroska_cluster *Cluster, ebml_master *SegmentInfo, bool_t UseForWriteToo);
-MATROSKA_DLL err_t MATROSKA_LinkBlockWithReadTracks(matroska_block *Block, ebml_master *Tracks, bool_t UseForWriteToo);
-MATROSKA_DLL err_t MATROSKA_LinkBlockReadTrack(matroska_block *Block, ebml_master *Track, bool_t UseForWriteToo);
+MATROSKA_DLL err_t MATROSKA_LinkBlockWithReadTracks(matroska_block *Block, ebml_master *Tracks, bool_t UseForWriteToo, int ForProfile);
+MATROSKA_DLL err_t MATROSKA_LinkBlockReadTrack(matroska_block *Block, ebml_master *Track, bool_t UseForWriteToo, int ForProfile);
 MATROSKA_DLL err_t MATROSKA_LinkBlockReadSegmentInfo(matroska_block *Block, ebml_master *SegmentInfo, bool_t UseForWriteToo);
 #if defined(CONFIG_EBML_WRITING)
 MATROSKA_DLL err_t MATROSKA_LinkClusterWriteSegmentInfo(matroska_cluster *Cluster, ebml_master *SegmentInfo);
-MATROSKA_DLL err_t MATROSKA_LinkBlockWithWriteTracks(matroska_block *Block, ebml_master *Tracks);
-MATROSKA_DLL err_t MATROSKA_LinkBlockWriteTrack(matroska_block *Block, ebml_master *Track);
+MATROSKA_DLL err_t MATROSKA_LinkBlockWithWriteTracks(matroska_block *Block, ebml_master *Tracks, int ForProfile);
+MATROSKA_DLL err_t MATROSKA_LinkBlockWriteTrack(matroska_block *Block, ebml_master *Track, int ForProfile);
 MATROSKA_DLL err_t MATROSKA_LinkBlockWriteSegmentInfo(matroska_block *Block, ebml_master *SegmentInfo);
 #endif
 //MATROSKA_DLL err_t MATROSKA_LinkCueTrack(const ebml_element *Cue, ebml_element *Tracks);
 MATROSKA_DLL err_t MATROSKA_LinkCueSegmentInfo(matroska_cuepoint *Cue, ebml_master *SegmentInfo);
 MATROSKA_DLL err_t MATROSKA_LinkCuePointBlock(matroska_cuepoint *Cue, matroska_block *Block);
-MATROSKA_DLL err_t MATROSKA_CuePointUpdate(matroska_cuepoint *Cue, ebml_element *Segment);
+MATROSKA_DLL err_t MATROSKA_CuePointUpdate(matroska_cuepoint *Cue, ebml_element *Segment, int ForProfile);
 MATROSKA_DLL double MATROSKA_TrackTimecodeScale(const ebml_master *Track);
 MATROSKA_DLL timecode_t MATROSKA_SegmentInfoTimecodeScale(const ebml_master *SegmentInfo);
 MATROSKA_DLL void MATROSKA_ClusterSetTimecode(matroska_cluster *Cluster, timecode_t Timecode);
@@ -150,7 +152,7 @@ MATROSKA_DLL int16_t MATROSKA_BlockTrackNum(const matroska_block *Block);
 MATROSKA_DLL bool_t MATROSKA_BlockKeyframe(const matroska_block *Block);
 MATROSKA_DLL bool_t MATROSKA_BlockDiscardable(const matroska_block *Block);
 MATROSKA_DLL bool_t MATROSKA_BlockLaced(const matroska_block *Block);
-MATROSKA_DLL err_t MATROSKA_BlockReadData(matroska_block *Block, stream *Input);
+MATROSKA_DLL err_t MATROSKA_BlockReadData(matroska_block *Block, stream *Input, int ForProfile);
 MATROSKA_DLL err_t MATROSKA_BlockReleaseData(matroska_block *Block, bool_t IncludingNotRead);
 MATROSKA_DLL int16_t MATROSKA_CueTrackNum(const matroska_cuepoint *Cue);
 MATROSKA_DLL void MATROSKA_CuesSort(ebml_master *Cues);
@@ -163,9 +165,9 @@ MATROSKA_DLL filepos_t MATROSKA_MetaSeekAbsolutePos(const matroska_seekpoint *Me
 MATROSKA_DLL matroska_cuepoint *MATROSKA_CuesGetTimecodeStart(const ebml_element *Cues, timecode_t Timecode);
 
 #if defined(CONFIG_EBML_WRITING)
-MATROSKA_DLL int MATROSKA_TrackGetBlockCompression(const matroska_trackentry *TrackEntry);
-MATROSKA_DLL bool_t MATROSKA_TrackSetCompressionZlib(matroska_trackentry *TrackEntry, int Scope);
-MATROSKA_DLL bool_t MATROSKA_TrackSetCompressionHeader(matroska_trackentry *TrackEntry, const uint8_t *Header, size_t HeaderSize);
+MATROSKA_DLL int MATROSKA_TrackGetBlockCompression(const matroska_trackentry *TrackEntry, int ForProfile);
+MATROSKA_DLL bool_t MATROSKA_TrackSetCompressionZlib(matroska_trackentry *TrackEntry, int Scope, int ForProfile);
+MATROSKA_DLL bool_t MATROSKA_TrackSetCompressionHeader(matroska_trackentry *TrackEntry, const uint8_t *Header, size_t HeaderSize, int ForProfile);
 MATROSKA_DLL bool_t MATROSKA_TrackSetCompressionNone(matroska_trackentry *TrackEntry);
 #if defined(CONFIG_ZLIB)
 MATROSKA_DLL err_t CompressFrameZLib(const uint8_t *Cursor, size_t CursorSize, uint8_t **OutBuf, size_t *OutSize);
@@ -189,7 +191,7 @@ MATROSKA_DLL ebml_element *MATROSKA_BlockWriteSegmentInfo(const matroska_block *
 MATROSKA_DLL err_t MATROSKA_BlockSkipToFrame(const matroska_block *Block, stream *Input, size_t FrameNum);
 MATROSKA_DLL void MATROSKA_BlockSetKeyframe(matroska_block *Block, bool_t Set);
 MATROSKA_DLL void MATROSKA_BlockSetDiscardable(matroska_block *Block, bool_t Set);
-MATROSKA_DLL err_t MATROSKA_BlockProcessFrameDurations(matroska_block *Block, stream *Input);
+MATROSKA_DLL err_t MATROSKA_BlockProcessFrameDurations(matroska_block *Block, stream *Input, int ForProfile);
 MATROSKA_DLL size_t MATROSKA_BlockGetFrameCount(const matroska_block *Block);
 MATROSKA_DLL timecode_t MATROSKA_BlockGetFrameDuration(const matroska_block *Block, size_t FrameNum);
 MATROSKA_DLL timecode_t MATROSKA_BlockGetFrameStart(const matroska_block *Block, size_t FrameNum);
@@ -202,7 +204,7 @@ MATROSKA_DLL bool_t MATROSKA_BlockIsKeyframe(const matroska_block *Block);
 
 
 MATROSKA_DLL matroska_block *MATROSKA_GetBlockForTimecode(matroska_cluster *Cluster, timecode_t Timecode, int16_t Track);
-MATROSKA_DLL void MATROSKA_LinkClusterBlocks(matroska_cluster *Cluster, ebml_master *RSegmentInfo, ebml_master *Tracks, bool_t KeepUnmatched);
+MATROSKA_DLL void MATROSKA_LinkClusterBlocks(matroska_cluster *Cluster, ebml_master *RSegmentInfo, ebml_master *Tracks, bool_t KeepUnmatched, int ForProfile);
 
 MATROSKA_DLL const ebml_context *MATROSKA_getContextStream();
 

--- a/libmatroska2/matroskablock.c
+++ b/libmatroska2/matroskablock.c
@@ -67,7 +67,7 @@ static const int A_DTS_freq[16] = {
 };
 
 
-err_t MATROSKA_BlockProcessFrameDurations(matroska_block *Block, stream *Input)
+err_t MATROSKA_BlockProcessFrameDurations(matroska_block *Block, stream *Input, int ForProfile)
 {
     ebml_master *Track=NULL;
     ebml_element *Elt;
@@ -100,7 +100,7 @@ err_t MATROSKA_BlockProcessFrameDurations(matroska_block *Block, stream *Input)
                     ReadData = 0;
                     if (!ArraySize(&Block->Data))
                     {
-                        Err = MATROSKA_BlockReadData(Block,Input);
+                        Err = MATROSKA_BlockReadData(Block,Input,ForProfile);
                         if (Err!=ERR_NONE)
                             goto exit;
                         ReadData = 1;

--- a/libmatroska2/matroskamain.c
+++ b/libmatroska2/matroskamain.c
@@ -1762,7 +1762,6 @@ static err_t RenderBlockData(matroska_block *Element, stream *Output, bool_t bFo
     uint8_t BlockHead[5], *Cursor;
     size_t ToWrite, Written, BlockHeadSize = 4;
     ebml_element *Elt, *Elt2, *Header = NULL;
-    int32_t *i;
     int CompressionScope = MATROSKA_COMPR_SCOPE_BLOCK;
     assert(Element->Lacing != LACING_AUTO);
 
@@ -1903,6 +1902,7 @@ static err_t RenderBlockData(matroska_block *Element, stream *Output, bool_t bFo
     Cursor = ARRAYBEGIN(Element->Data,uint8_t);
     if (Header && (CompressionScope & MATROSKA_COMPR_SCOPE_BLOCK))
     {
+        int32_t* i;
         if (Header && Header->Context==MATROSKA_getContextContentCompAlgo())
         {
 #if defined(CONFIG_ZLIB)
@@ -2285,8 +2285,8 @@ static err_t ReadTrackEntry(matroska_trackentry *Element, stream *Input, const e
                 ebml_element *Elt =  EBML_MasterFindChild((ebml_master*)Elt2,MATROSKA_getContextContentCompression());
                 if (Elt)
                 {
-                    ebml_integer *Scope =  (ebml_integer*)EBML_MasterFindChild((ebml_master*)Elt2,MATROSKA_getContextContentEncodingScope());
-                    Element->CodecPrivateCompressed = Scope && (EBML_IntegerValue(Scope) & MATROSKA_COMPR_SCOPE_PRIVATE)!=0;
+                    ebml_integer *EncScope =  (ebml_integer*)EBML_MasterFindChild((ebml_master*)Elt2,MATROSKA_getContextContentEncodingScope());
+                    Element->CodecPrivateCompressed = EncScope && (EBML_IntegerValue(EncScope) & MATROSKA_COMPR_SCOPE_PRIVATE)!=0;
                 }
             }
         }

--- a/libmatroska2/test/mkvtree.c
+++ b/libmatroska2/test/mkvtree.c
@@ -106,6 +106,7 @@ static ebml_element *OutputElement(ebml_element *Element, const ebml_parser_cont
         SubContext.UpContext = Context;
         SubContext.Context = EBML_ElementContext(Element);
         SubContext.EndPosition = EBML_ElementPositionEnd(Element);
+        SubContext.Profile = Context->Profile;
         SubElement = EBML_FindNextElement(Input, &SubContext, &UpperElement, 1);
 		while (SubElement != NULL && UpperElement<=0 && (!EBML_ElementIsFiniteSize(Element) || EBML_ElementPosition(SubElement) <= EBML_ElementPositionEnd(Element)))
         {
@@ -243,7 +244,7 @@ static ebml_element *OutputElement(ebml_element *Element, const ebml_parser_cont
 
 static void OutputTree(stream *Input)
 {
-    ebml_element *Element = EBML_ElementCreate(Input,MATROSKA_getContextStream(),0,NULL);
+    ebml_element *Element = EBML_ElementCreate(Input,MATROSKA_getContextStream(),0,PROFILE_MATROSKA_ANY,NULL);
     if (Element)
     {
 		int Level = -1;

--- a/mkclean/mkclean.c
+++ b/mkclean/mkclean.c
@@ -1287,12 +1287,16 @@ static int CleanTracks(ebml_master *Tracks, int srcProfile, int *dstProfile, ebm
             NodeTree_SetParent(Elt,Track,EBML_MasterChildren(Track));
 
         Elt2 = EBML_MasterFindChild(Track,MATROSKA_getContextTrackType());
-        assert(Elt2!=NULL);
-        NodeTree_SetParent(Elt2,Track,EBML_MasterNext(Elt));
+        assert(Elt2 != NULL);
+        if (Elt2)
+        {
+            if (Elt)
+                NodeTree_SetParent(Elt2, Track, EBML_MasterNext(Elt));
 
-        DisplayW = EBML_MasterFindChild(Track,MATROSKA_getContextCodecID());
-        if (DisplayW)
-            NodeTree_SetParent(DisplayW,Track,EBML_MasterNext(Elt2));
+            DisplayW = EBML_MasterFindChild(Track, MATROSKA_getContextCodecID());
+            if (DisplayW)
+                NodeTree_SetParent(DisplayW, Track, EBML_MasterNext(Elt2));
+        }
     }
 
     return 0;

--- a/mkparts/mkparts.c
+++ b/mkparts/mkparts.c
@@ -217,7 +217,7 @@ int main(int argc, const char *argv[])
     RContext.Context = MATROSKA_getContextStream();
     RContext.EndPosition = INVALID_FILEPOS_T;
     RContext.UpContext = NULL;
-    RContext.Profile = 0;
+    RContext.Profile = EBML_ANY_PROFILE;
 
     EbmlHead = EBML_FindNextElement(Input, &RContext, &UpperElement, 0);
     while (EbmlHead!=NULL)

--- a/mkvalidator/mkvalidator.c
+++ b/mkvalidator/mkvalidator.c
@@ -389,10 +389,10 @@ static int CheckTracks(ebml_master *Tracks, int ProfileNum)
                     Result |= OutputError(0x306,T("Track at %") TPRId64 T(" attachment link UID 0x%") TPRIx64 T(" not found in attachments"),EL_Pos(Track),EL_Int(TrackType));
             }
 
-            TrackType = EBML_MasterFindNextElt(Track, TrackType, 0, 0);
+            TrackType = EBML_MasterNextChild(Track, TrackType);
         }
 
-		Track = (ebml_master*)EBML_MasterFindNextElt(Tracks, (ebml_element*)Track, 0, 0);
+		Track = (ebml_master*)EBML_MasterNextChild(Tracks, Track);
 	}
 	return Result;
 }
@@ -535,7 +535,7 @@ static int CheckSeekHead(ebml_master *SeekHead)
 		}
 		else
 			OutputWarning(0x860,T("The SeekPoint at %") TPRId64 T(" references an element that is not a known level 1 ID %s at %") TPRId64 T(")"),EL_Pos(RLevel1),IdString,Pos);
-		RLevel1 = (matroska_seekpoint*)EBML_MasterFindNextElt(SeekHead, (ebml_element*)RLevel1, 0, 0);
+		RLevel1 = (matroska_seekpoint*)EBML_MasterNextChild(SeekHead, RLevel1);
 	}
     if (SeekHead == RSeekHead)
     {
@@ -576,7 +576,7 @@ static bool_t TrackIsLaced(int16_t TrackNum)
             TrackData = EBML_MasterGetChild(Track, MATROSKA_getContextFlagLacing());
             return EL_Int(TrackData) != 0;
         }
-        Track = (ebml_master*)EBML_MasterFindNextElt(RTrackInfo, (ebml_element*)Track, 0, 0);
+        Track = (ebml_master*)EBML_MasterNextChild(RTrackInfo, Track);
     }
     return 1;
 }
@@ -594,7 +594,7 @@ static bool_t TrackIsVideo(int16_t TrackNum)
             return EL_Int(TrackData) == TRACK_TYPE_VIDEO;
         }
         // look for TrackNum in the next Track
-        Track = (ebml_master*)EBML_MasterFindNextElt(RTrackInfo, (ebml_element*)Track, 0, 0);
+        Track = (ebml_master*)EBML_MasterNextChild(RTrackInfo, Track);
     }
     return 0;
 }
@@ -624,7 +624,7 @@ static bool_t TrackNeedsKeyframe(int16_t TrackNum)
             }
         }
         // look for TrackNum in the next Track
-        Track = (ebml_master*)EBML_MasterFindNextElt(RTrackInfo, (ebml_element*)Track, 0, 0);
+        Track = (ebml_master*)EBML_MasterNextChild(RTrackInfo, Track);
     }
     return 0;
 }
@@ -845,7 +845,7 @@ static int CheckCueEntries(ebml_master *Cues)
 			if (Cluster == ARRAYEND(RClusters,matroska_cluster*))
 				Result |= OutputError(0x312,T("CueEntry Track #%d and timecode %") TPRId64 T(" ms not found"),(int)TrackNumEntry,Scale64(TimecodeEntry,1,1000000));
 			PrevTimecode = TimecodeEntry;
-			CuePoint = (matroska_cuepoint*)EBML_MasterFindNextElt(Cues, (ebml_element*)CuePoint, 0, 0);
+			CuePoint = (matroska_cuepoint*)EBML_MasterNextChild(Cues, CuePoint);
 		}
 	}
 	return Result;

--- a/mkvalidator/mkvalidator.c
+++ b/mkvalidator/mkvalidator.c
@@ -292,14 +292,14 @@ static int CheckVideoTrack(ebml_master *Track, int TrackNum, int ProfileNum)
 	return Result;
 }
 
-static int CheckTracks(ebml_master *Tracks, int ProfileNum)
+static int CheckTracks(ebml_master *TrackEntries, int ProfileNum)
 {
 	ebml_master *Track;
 	ebml_element *TrackType, *TrackNum, *Elt, *Elt2;
 	ebml_string *CodecID;
 	tchar_t CodecName[MAXPATH],String[MAXPATH];
 	int Result = 0;
-	Track = (ebml_master*)EBML_MasterFindChild(Tracks, MATROSKA_getContextTrackEntry());
+	Track = (ebml_master*)EBML_MasterFindChild(TrackEntries, MATROSKA_getContextTrackEntry());
 	while (Track)
 	{
         // check if the codec is valid for the profile
@@ -392,7 +392,7 @@ static int CheckTracks(ebml_master *Tracks, int ProfileNum)
             TrackType = EBML_MasterNextChild(Track, TrackType);
         }
 
-		Track = (ebml_master*)EBML_MasterNextChild(Tracks, Track);
+		Track = (ebml_master*)EBML_MasterNextChild(TrackEntries, Track);
 	}
 	return Result;
 }
@@ -1367,7 +1367,6 @@ int main(int argc, const char *argv[])
         TextWrite(StdErr,T("\r") PROJECT_NAME T(" ") PROJECT_VERSION T(": the file appears to be valid\r\n"));
         if (Details)
         {
-            track_info *TI;
             for (TI=ARRAYBEGIN(Tracks,track_info); TI!=ARRAYEND(Tracks,track_info); ++TI)
             {
                 EBML_StringGet(TI->CodecID,String,TSIZEOF(String));


### PR DESCRIPTION
And some code/warning cleaning.
Now reading in mkclean/mkvalidator is tightly linked to the specified profile.