### PR TITLE
libmatroska2: rename all timecode API's to timestamp

### DIFF
--- a/libmatroska2/MatroskaParser/MatroskaParser.h
+++ b/libmatroska2/MatroskaParser/MatroskaParser.h
@@ -63,7 +63,7 @@ typedef struct TrackInfo
 
 	uint8_t *CodecPrivate;
 	size_t CodecPrivateSize;
-	timecode_t DefaultDuration;
+	mkv_timestamp_t DefaultDuration;
 	char *CodecID;
 	char *Name;
 	char Language[4];
@@ -72,7 +72,7 @@ typedef struct TrackInfo
 	bool_t Default;
 	bool_t Lacing;
 	bool_t DecodeAll;
-	float TimecodeScale;
+	float TimestampScale;
 
 	int TrackOverlay;
 	uint8_t MinCache;
@@ -131,8 +131,8 @@ typedef struct Chapter
 	size_t nDisplay;
 	struct ChapterDisplay *Display;
 
-	timecode_t Start;
-	timecode_t End;
+	mkv_timestamp_t Start;
+	mkv_timestamp_t End;
 	uint64_t UID;
 
 	bool_t Enabled;
@@ -190,8 +190,8 @@ typedef struct SegmentInfo
 	char *MuxingApp;
 	char *WritingApp;
 
-	timecode_t TimecodeScale;
-	timecode_t Duration;
+	mkv_timestamp_t TimestampScale;
+	mkv_timestamp_t Duration;
 
 	datetime_t DateUTC;
 
@@ -218,7 +218,7 @@ int mkv_ReadFrame(MatroskaFile *File, int mask, unsigned int *track, ulonglong *
 
 #define MKVF_SEEK_TO_PREV_KEYFRAME  1
 
-void mkv_Seek(MatroskaFile *File, timecode_t timecode, int flags);
+void mkv_Seek(MatroskaFile *File, mkv_timestamp_t timestamp, int flags);
 
 void mkv_GetTags(MatroskaFile *File, Tag **, unsigned *Count);
 void mkv_GetAttachments(MatroskaFile *File, Attachment **, unsigned *Count);

--- a/libmatroska2/matroska2/matroska.h
+++ b/libmatroska2/matroska2/matroska.h
@@ -72,8 +72,8 @@
 MATROSKA_DLL err_t MATROSKA_Init(parsercontext *p);
 MATROSKA_DLL void MATROSKA_Done(parsercontext *p);
 
-#define INVALID_TIMECODE_T      MAX_INT64
-typedef int64_t    timecode_t; // in nanoseconds
+#define INVALID_TIMESTAMP_T      MAX_INT64
+typedef int64_t    mkv_timestamp_t; // in nanoseconds
 
 #define TRACK_TYPE_VIDEO    1
 #define TRACK_TYPE_AUDIO    2
@@ -118,8 +118,8 @@ typedef struct matroska_frame
 {
     uint8_t *Data;
     uint32_t Size;
-    timecode_t Timecode;
-    timecode_t Duration;
+    mkv_timestamp_t Timestamp;
+    mkv_timestamp_t Duration;
 
 } matroska_frame;
 
@@ -139,14 +139,14 @@ MATROSKA_DLL err_t MATROSKA_LinkBlockWriteSegmentInfo(matroska_block *Block, ebm
 MATROSKA_DLL err_t MATROSKA_LinkCueSegmentInfo(matroska_cuepoint *Cue, ebml_master *SegmentInfo);
 MATROSKA_DLL err_t MATROSKA_LinkCuePointBlock(matroska_cuepoint *Cue, matroska_block *Block);
 MATROSKA_DLL err_t MATROSKA_CuePointUpdate(matroska_cuepoint *Cue, ebml_element *Segment, int ForProfile);
-MATROSKA_DLL double MATROSKA_TrackTimecodeScale(const ebml_master *Track);
-MATROSKA_DLL timecode_t MATROSKA_SegmentInfoTimecodeScale(const ebml_master *SegmentInfo);
-MATROSKA_DLL void MATROSKA_ClusterSetTimecode(matroska_cluster *Cluster, timecode_t Timecode);
-MATROSKA_DLL err_t MATROSKA_BlockSetTimecode(matroska_block *Block, timecode_t Timecode, timecode_t ClusterTimecode);
-MATROSKA_DLL timecode_t MATROSKA_ClusterTimecode(matroska_cluster *Cluster);
-MATROSKA_DLL timecode_t MATROSKA_ClusterTimecodeScale(matroska_cluster *Cluster, bool_t Read);
-MATROSKA_DLL timecode_t MATROSKA_BlockTimecode(matroska_block *Block);
-MATROSKA_DLL timecode_t MATROSKA_CueTimecode(const matroska_cuepoint *Cue);
+MATROSKA_DLL double MATROSKA_TrackTimestampScale(const ebml_master *Track);
+MATROSKA_DLL mkv_timestamp_t MATROSKA_SegmentInfoTimestampScale(const ebml_master *SegmentInfo);
+MATROSKA_DLL void MATROSKA_ClusterSetTimestamp(matroska_cluster *Cluster, mkv_timestamp_t Timestamp);
+MATROSKA_DLL err_t MATROSKA_BlockSetTimestamp(matroska_block *Block, mkv_timestamp_t Timestamp, mkv_timestamp_t ClusterTimestamp);
+MATROSKA_DLL mkv_timestamp_t MATROSKA_ClusterTimestamp(matroska_cluster *Cluster);
+MATROSKA_DLL mkv_timestamp_t MATROSKA_ClusterTimestampScale(matroska_cluster *Cluster, bool_t Read);
+MATROSKA_DLL mkv_timestamp_t MATROSKA_BlockTimestamp(matroska_block *Block);
+MATROSKA_DLL mkv_timestamp_t MATROSKA_CueTimestamp(const matroska_cuepoint *Cue);
 MATROSKA_DLL filepos_t MATROSKA_CuePosInSegment(const matroska_cuepoint *Cue);
 MATROSKA_DLL int16_t MATROSKA_BlockTrackNum(const matroska_block *Block);
 MATROSKA_DLL bool_t MATROSKA_BlockKeyframe(const matroska_block *Block);
@@ -162,7 +162,7 @@ MATROSKA_DLL bool_t MATROSKA_MetaSeekIsClass(const matroska_seekpoint *MetaSeek,
 MATROSKA_DLL filepos_t MATROSKA_MetaSeekPosInSegment(const matroska_seekpoint *MetaSeek);
 MATROSKA_DLL filepos_t MATROSKA_MetaSeekAbsolutePos(const matroska_seekpoint *MetaSeek);
 
-MATROSKA_DLL matroska_cuepoint *MATROSKA_CuesGetTimecodeStart(const ebml_element *Cues, timecode_t Timecode);
+MATROSKA_DLL matroska_cuepoint *MATROSKA_CuesGetTimestampStart(const ebml_element *Cues, mkv_timestamp_t Timestamp);
 
 #if defined(CONFIG_EBML_WRITING)
 MATROSKA_DLL int MATROSKA_TrackGetBlockCompression(const matroska_trackentry *TrackEntry, int ForProfile);
@@ -193,17 +193,17 @@ MATROSKA_DLL void MATROSKA_BlockSetKeyframe(matroska_block *Block, bool_t Set);
 MATROSKA_DLL void MATROSKA_BlockSetDiscardable(matroska_block *Block, bool_t Set);
 MATROSKA_DLL err_t MATROSKA_BlockProcessFrameDurations(matroska_block *Block, stream *Input, int ForProfile);
 MATROSKA_DLL size_t MATROSKA_BlockGetFrameCount(const matroska_block *Block);
-MATROSKA_DLL timecode_t MATROSKA_BlockGetFrameDuration(const matroska_block *Block, size_t FrameNum);
-MATROSKA_DLL timecode_t MATROSKA_BlockGetFrameStart(const matroska_block *Block, size_t FrameNum);
-MATROSKA_DLL timecode_t MATROSKA_BlockGetFrameEnd(const matroska_block *Block, size_t FrameNum);
+MATROSKA_DLL mkv_timestamp_t MATROSKA_BlockGetFrameDuration(const matroska_block *Block, size_t FrameNum);
+MATROSKA_DLL mkv_timestamp_t MATROSKA_BlockGetFrameStart(const matroska_block *Block, size_t FrameNum);
+MATROSKA_DLL mkv_timestamp_t MATROSKA_BlockGetFrameEnd(const matroska_block *Block, size_t FrameNum);
 MATROSKA_DLL size_t MATROSKA_BlockGetLength(const matroska_block *Block, size_t FrameNum);
 
 MATROSKA_DLL err_t MATROSKA_BlockGetFrame(const matroska_block *Block, size_t FrameNum, matroska_frame *Frame, bool_t WithData);
-MATROSKA_DLL err_t MATROSKA_BlockAppendFrame(matroska_block *Block, const matroska_frame *Frame, timecode_t ClusterTimecode);
+MATROSKA_DLL err_t MATROSKA_BlockAppendFrame(matroska_block *Block, const matroska_frame *Frame, mkv_timestamp_t ClusterTimestamp);
 MATROSKA_DLL bool_t MATROSKA_BlockIsKeyframe(const matroska_block *Block);
 
 
-MATROSKA_DLL matroska_block *MATROSKA_GetBlockForTimecode(matroska_cluster *Cluster, timecode_t Timecode, int16_t Track);
+MATROSKA_DLL matroska_block *MATROSKA_GetBlockForTimestamp(matroska_cluster *Cluster, mkv_timestamp_t Timestamp, int16_t Track);
 MATROSKA_DLL void MATROSKA_LinkClusterBlocks(matroska_cluster *Cluster, ebml_master *RSegmentInfo, ebml_master *Tracks, bool_t KeepUnmatched, int ForProfile);
 
 MATROSKA_DLL const ebml_context *MATROSKA_getContextStream();

--- a/libmatroska2/matroska2/matroska_classes.h
+++ b/libmatroska2/matroska2/matroska_classes.h
@@ -45,12 +45,12 @@
 struct matroska_block
 {
     ebml_binary Base;
-	timecode_t GlobalTimecode;
+    mkv_timestamp_t GlobalTimestamp;
     filepos_t FirstFrameLocation;
     array SizeList; // int32_t
     array SizeListIn; // int32_t
     array Data; // uint8_t
-    array Durations; // timecode_t
+    array Durations; // mkv_timestamp_t
     ebml_master *ReadTrack;
     ebml_master *ReadSegInfo;
 #if defined(CONFIG_EBML_WRITING)
@@ -60,8 +60,8 @@ struct matroska_block
     bool_t IsKeyframe;
     bool_t IsDiscardable;
     bool_t Invisible;
-    bool_t LocalTimecodeUsed;
-    int16_t LocalTimecode;
+    bool_t LocalTimestampUsed;
+    int16_t LocalTimestamp;
     uint16_t TrackNumber;
     char Lacing;
 };

--- a/libmatroska2/matroskablock.c
+++ b/libmatroska2/matroskablock.c
@@ -109,7 +109,7 @@ err_t MATROSKA_BlockProcessFrameDurations(matroska_block *Block, stream *Input, 
                     if (tcsisame_ascii(CodecID,T("A_MPEG/L3")) || tcsisame_ascii(CodecID,T("A_MPEG/L2")) || tcsisame_ascii(CodecID,T("A_MPEG/L1")))
                     {
                         Block->IsKeyframe = 1; // safety
-                        ArrayResize(&Block->Durations,sizeof(timecode_t)*ARRAYCOUNT(Block->SizeList,int32_t),0);
+                        ArrayResize(&Block->Durations,sizeof(mkv_timestamp_t)*ARRAYCOUNT(Block->SizeList,int32_t),0);
                         Cursor = ARRAYBEGIN(Block->Data,uint8_t);
                         for (Frame=0;Frame<ARRAYCOUNT(Block->SizeList,int32_t);++Frame)
                         {
@@ -120,11 +120,11 @@ err_t MATROSKA_BlockProcessFrameDurations(matroska_block *Block, stream *Input, 
                             Samples = A_MPEG_samples[Layer][Version];
                             SampleRate = A_MPEG_freq[SampleRate][Version];
                             if (SampleRate!=0 && Samples!=0)
-                                ARRAYBEGIN(Block->Durations,timecode_t)[Frame] = Scale64(1000000000,Samples,SampleRate);
+                                ARRAYBEGIN(Block->Durations,mkv_timestamp_t)[Frame] = Scale64(1000000000,Samples,SampleRate);
                             else
                             {
                                 Err = ERR_INVALID_DATA;
-                                ARRAYBEGIN(Block->Durations,timecode_t)[Frame] = INVALID_TIMECODE_T;
+                                ARRAYBEGIN(Block->Durations,mkv_timestamp_t)[Frame] = INVALID_TIMESTAMP_T;
                                 //goto exit;
                             }
 
@@ -134,7 +134,7 @@ err_t MATROSKA_BlockProcessFrameDurations(matroska_block *Block, stream *Input, 
                     else if (tcsisame_ascii(CodecID,T("A_AC3")))
                     {
                         Block->IsKeyframe = 1; // safety
-                        ArrayResize(&Block->Durations,sizeof(timecode_t)*ARRAYCOUNT(Block->SizeList,int32_t),0);
+                        ArrayResize(&Block->Durations,sizeof(mkv_timestamp_t)*ARRAYCOUNT(Block->SizeList,int32_t),0);
                         Cursor = ARRAYBEGIN(Block->Data,uint8_t);
                         for (Frame=0;Frame<ARRAYCOUNT(Block->SizeList,int32_t);++Frame)
                         {
@@ -143,13 +143,13 @@ err_t MATROSKA_BlockProcessFrameDurations(matroska_block *Block, stream *Input, 
                             if (fscod > 10 || fscod < 8)
                             {
                                 Err = ERR_INVALID_DATA;
-                                ARRAYBEGIN(Block->Durations,timecode_t)[Frame] = INVALID_TIMECODE_T;
+                                ARRAYBEGIN(Block->Durations,mkv_timestamp_t)[Frame] = INVALID_TIMESTAMP_T;
                                 //goto exit;
                             }
                             else
                             {
                                 SampleRate = A_AC3_freq[fscod-8][SampleRate];
-                                ARRAYBEGIN(Block->Durations,timecode_t)[Frame] = Scale64(1000000000,1536,SampleRate);
+                                ARRAYBEGIN(Block->Durations,mkv_timestamp_t)[Frame] = Scale64(1000000000,1536,SampleRate);
                             }
                             Cursor += ARRAYBEGIN(Block->SizeList,int32_t)[Frame];
                         }
@@ -157,7 +157,7 @@ err_t MATROSKA_BlockProcessFrameDurations(matroska_block *Block, stream *Input, 
                     else if (tcsisame_ascii(CodecID,T("A_EAC3")))
                     {
                         Block->IsKeyframe = 1; // safety
-                        ArrayResize(&Block->Durations,sizeof(timecode_t)*ARRAYCOUNT(Block->SizeList,int32_t),0);
+                        ArrayResize(&Block->Durations,sizeof(mkv_timestamp_t)*ARRAYCOUNT(Block->SizeList,int32_t),0);
                         Cursor = ARRAYBEGIN(Block->Data,uint8_t);
                         for (Frame=0;Frame<ARRAYCOUNT(Block->SizeList,int32_t);++Frame)
                         {
@@ -166,14 +166,14 @@ err_t MATROSKA_BlockProcessFrameDurations(matroska_block *Block, stream *Input, 
                             if ((0x03 == fscod) && (0x03 == fscod2))
                             {
                                 Err = ERR_INVALID_DATA;
-                                ARRAYBEGIN(Block->Durations,timecode_t)[Frame] = INVALID_TIMECODE_T;
+                                ARRAYBEGIN(Block->Durations,mkv_timestamp_t)[Frame] = INVALID_TIMESTAMP_T;
                                 //goto exit;
                             }
                             else
                             {
                                 SampleRate = A_EAC3_freq[0x03 == fscod ? 3 + fscod2 : fscod];
                                 Samples = (0x03 == fscod) ? 1536 : A_EAC3_samples[fscod2];
-                                ARRAYBEGIN(Block->Durations,timecode_t)[Frame] = Scale64(1000000000,Samples,SampleRate);
+                                ARRAYBEGIN(Block->Durations,mkv_timestamp_t)[Frame] = Scale64(1000000000,Samples,SampleRate);
                             }
                             Cursor += ARRAYBEGIN(Block->SizeList,int32_t)[Frame];
                         }
@@ -181,7 +181,7 @@ err_t MATROSKA_BlockProcessFrameDurations(matroska_block *Block, stream *Input, 
                     else if (tcsisame_ascii(CodecID,T("A_DTS")))
                     {
                         Block->IsKeyframe = 1; // safety
-                        ArrayResize(&Block->Durations,sizeof(timecode_t)*ARRAYCOUNT(Block->SizeList,int32_t),0);
+                        ArrayResize(&Block->Durations,sizeof(mkv_timestamp_t)*ARRAYCOUNT(Block->SizeList,int32_t),0);
                         Cursor = ARRAYBEGIN(Block->Data,uint8_t);
                         for (Frame=0;Frame<ARRAYCOUNT(Block->SizeList,int32_t);++Frame)
                         {
@@ -191,11 +191,11 @@ err_t MATROSKA_BlockProcessFrameDurations(matroska_block *Block, stream *Input, 
                             if (Samples==0 || SampleRate==0)
                             {
                                 Err = ERR_INVALID_DATA;
-                                ARRAYBEGIN(Block->Durations,timecode_t)[Frame] = INVALID_TIMECODE_T;
+                                ARRAYBEGIN(Block->Durations,mkv_timestamp_t)[Frame] = INVALID_TIMESTAMP_T;
                                 //goto exit;
                             }
                             else
-                                ARRAYBEGIN(Block->Durations,timecode_t)[Frame] = Scale64(1000000000,Samples,SampleRate);
+                                ARRAYBEGIN(Block->Durations,mkv_timestamp_t)[Frame] = Scale64(1000000000,Samples,SampleRate);
                             Cursor += ARRAYBEGIN(Block->SizeList,int32_t)[Frame];
                         }
                     }
@@ -208,11 +208,11 @@ err_t MATROSKA_BlockProcessFrameDurations(matroska_block *Block, stream *Input, 
                             Elt = EBML_MasterFindChild((ebml_master*)Elt,MATROSKA_getContextSamplingFrequency());
                             if (Elt)
                             {
-                                ArrayResize(&Block->Durations,sizeof(timecode_t)*ARRAYCOUNT(Block->SizeList,int32_t),0);
+                                ArrayResize(&Block->Durations,sizeof(mkv_timestamp_t)*ARRAYCOUNT(Block->SizeList,int32_t),0);
                                 Samples = 1024;
                                 SampleRate = (int)((ebml_float*)Elt)->Value;
                                 for (Frame=0;Frame<ARRAYCOUNT(Block->SizeList,int32_t);++Frame)
-                                    ARRAYBEGIN(Block->Durations,timecode_t)[Frame] = Scale64(1000000000,Samples,SampleRate);
+                                    ARRAYBEGIN(Block->Durations,mkv_timestamp_t)[Frame] = Scale64(1000000000,Samples,SampleRate);
                             }
                         }
                     }
@@ -285,7 +285,7 @@ err_t MATROSKA_BlockProcessFrameDurations(matroska_block *Block, stream *Input, 
                             }
 
                             SampleRate = vi.rate;
-                            ArrayResize(&Block->Durations,sizeof(timecode_t)*ARRAYCOUNT(Block->SizeList,int32_t),0);
+                            ArrayResize(&Block->Durations,sizeof(mkv_timestamp_t)*ARRAYCOUNT(Block->SizeList,int32_t),0);
                             Cursor = ARRAYBEGIN(Block->Data,uint8_t);
                             ci = vi.codec_setup;
                             for (Frame=0;Frame<ARRAYCOUNT(Block->SizeList,int32_t);++Frame)
@@ -295,13 +295,13 @@ err_t MATROSKA_BlockProcessFrameDurations(matroska_block *Block, stream *Input, 
                                 if (fscod > ci->modes)
                                 {
                                     Err = ERR_INVALID_DATA;
-                                    ARRAYBEGIN(Block->Durations,timecode_t)[Frame] = INVALID_TIMECODE_T;
+                                    ARRAYBEGIN(Block->Durations,mkv_timestamp_t)[Frame] = INVALID_TIMESTAMP_T;
                                     //goto exit;
                                 }
                                 else
                                 {
                                     Samples = ci->blocksizes[ci->mode_param[fscod]->blockflag];
-                                    ARRAYBEGIN(Block->Durations,timecode_t)[Frame] = Scale64(1000000000,Samples,SampleRate);
+                                    ARRAYBEGIN(Block->Durations,mkv_timestamp_t)[Frame] = Scale64(1000000000,Samples,SampleRate);
                                 }
                                 Cursor += ARRAYBEGIN(Block->SizeList,int32_t)[Frame];
                             }
@@ -336,41 +336,41 @@ size_t MATROSKA_BlockGetLength(const matroska_block *Block, size_t FrameNum)
 	return ARRAYBEGIN(Block->SizeList,int32_t)[FrameNum];
 }
 
-timecode_t MATROSKA_BlockGetFrameDuration(const matroska_block *Block, size_t FrameNum)
+mkv_timestamp_t MATROSKA_BlockGetFrameDuration(const matroska_block *Block, size_t FrameNum)
 {
-    if (FrameNum >= ARRAYCOUNT(Block->Durations,timecode_t))
-        return INVALID_TIMECODE_T;
-    return ARRAYBEGIN(Block->Durations,timecode_t)[FrameNum];
+    if (FrameNum >= ARRAYCOUNT(Block->Durations,mkv_timestamp_t))
+        return INVALID_TIMESTAMP_T;
+    return ARRAYBEGIN(Block->Durations,mkv_timestamp_t)[FrameNum];
 }
 
-timecode_t MATROSKA_BlockGetFrameStart(const matroska_block *Block, size_t FrameNum)
+mkv_timestamp_t MATROSKA_BlockGetFrameStart(const matroska_block *Block, size_t FrameNum)
 {
-    if (FrameNum >= ARRAYCOUNT(Block->Durations,timecode_t))
-        return INVALID_TIMECODE_T;
+    if (FrameNum >= ARRAYCOUNT(Block->Durations,mkv_timestamp_t))
+        return INVALID_TIMESTAMP_T;
     else
     {
         size_t i;
-        timecode_t Start = MATROSKA_BlockTimecode((matroska_block*)Block);
-        if (Start!=INVALID_TIMECODE_T)
+        mkv_timestamp_t Start = MATROSKA_BlockTimestamp((matroska_block*)Block);
+        if (Start!=INVALID_TIMESTAMP_T)
         {
             for (i=0;i<FrameNum;++i)
             {
-                if (ARRAYBEGIN(Block->Durations,timecode_t)[i]==INVALID_TIMECODE_T)
-                    return INVALID_TIMECODE_T;
-                Start += ARRAYBEGIN(Block->Durations,timecode_t)[i];
+                if (ARRAYBEGIN(Block->Durations,mkv_timestamp_t)[i]==INVALID_TIMESTAMP_T)
+                    return INVALID_TIMESTAMP_T;
+                Start += ARRAYBEGIN(Block->Durations,mkv_timestamp_t)[i];
             }
         }
         return Start;
     }
 }
 
-timecode_t MATROSKA_BlockGetFrameEnd(const matroska_block *Block, size_t FrameNum)
+mkv_timestamp_t MATROSKA_BlockGetFrameEnd(const matroska_block *Block, size_t FrameNum)
 {
-    timecode_t Result = MATROSKA_BlockGetFrameStart(Block,FrameNum), a;
-    if (Result==INVALID_TIMECODE_T)
-        return INVALID_TIMECODE_T;
+    mkv_timestamp_t Result = MATROSKA_BlockGetFrameStart(Block,FrameNum), a;
+    if (Result==INVALID_TIMESTAMP_T)
+        return INVALID_TIMESTAMP_T;
     a = MATROSKA_BlockGetFrameDuration(Block,FrameNum);
-    if (a==INVALID_TIMECODE_T)
-        return INVALID_TIMECODE_T;
+    if (a==INVALID_TIMESTAMP_T)
+        return INVALID_TIMESTAMP_T;
     return Result + a;
 }


### PR DESCRIPTION
The `--timecodescale` option of mkclean remains for now.

Given noone outside of this code tree is using libmatroska2 that shouldn't be a problem.