### PR TITLE
Add appropriate inttypes.h headers to test files

### DIFF
--- a/libebml2/test/ebmltree.c
+++ b/libebml2/test/ebmltree.c
@@ -26,6 +26,8 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 #include <stdio.h>
 
 #include "ebml2/ebml.h"

--- a/libmatroska2/test/mkvtree.c
+++ b/libmatroska2/test/mkvtree.c
@@ -26,6 +26,8 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#define __STDC_FORMAT_MACROS
+#include <inttypes.h>
 #include <stdio.h>
 
 #include "matroska2/matroska.h"


### PR DESCRIPTION
When compiling mkclean from source on CentOS 7 (GCC 4.8.5), the use of PRIdPTR was causing a compilation error because the inttypes.h header and appropriate macro were not present in the offending test files.

Monkey-patching the lines into the test files fixed the compilation error, so I thought I'd create a pull here.