### PR TITLE
mkclean: read non-wide filenames as UTF-8

### DIFF
--- a/mkclean/mkclean.c
+++ b/mkclean/mkclean.c
@@ -1571,7 +1571,7 @@ int main(int argc, const char *argv[])
 #if defined(TARGET_WIN) && defined(UNICODE)
     Node_FromWcs(&p,Path,TSIZEOF(Path),argv[InputPathIndex]);
 #else
-    Node_FromStr(&p,Path,TSIZEOF(Path),argv[InputPathIndex]);
+    Node_FromUTF8(&p,Path,TSIZEOF(Path),argv[InputPathIndex]);
 #endif
     Input = StreamOpen(&p,Path,SFLAG_RDONLY/*|SFLAG_BUFFERED*/);
     if (!Input)


### PR DESCRIPTION
This is the default on Linux and MacOS (and recently on Windows AFAIK)