### PR TITLE
spectool: fix KaxSemantic generator with latest Schema

### DIFF
--- a/spectool/schema_2_kaxsematic_cpp.xsl
+++ b/spectool/schema_2_kaxsematic_cpp.xsl
@@ -150,7 +150,7 @@ END_LIBMATROSKA_NAMESPACE
                 <xsl:text>DEFINE_MKX_BINARY</xsl:text>
                 <xsl:choose>
                     <!-- Needs a special constructor -->
-                    <xsl:when test="@name='Block' or @name='SimpleBlock' or @name='BlockVirtual' or @name='NextUID' or @name='PrevUID'"><xsl:text>_CONS</xsl:text></xsl:when>
+                    <xsl:when test="@name='Block' or @name='SimpleBlock' or @name='BlockVirtual' or @name='NextUUID' or @name='PrevUUID'"><xsl:text>_CONS</xsl:text></xsl:when>
                     <xsl:otherwise><xsl:text> </xsl:text></xsl:otherwise>
                 </xsl:choose>
                 <xsl:text>(Kax</xsl:text>
@@ -478,7 +478,7 @@ END_LIBMATROSKA_NAMESPACE
 <xsl:value-of select="ebml:extension[@cppname][1]/@cppname" /><xsl:text>/ </xsl:text> -->
     <xsl:choose>
         <xsl:when test="$node/@name='AttachedFile'"><xsl:value-of select="$node/@name" /></xsl:when>
-        <xsl:when test="$node/@name='FileMimeType'"><xsl:value-of select="$node/@name" /></xsl:when>
+        <xsl:when test="$node/@name='FileMediaType'"><xsl:text>FileMimeType</xsl:text></xsl:when>
         <xsl:when test="$node/@name='SeekHead'"><xsl:text>SeekHeader</xsl:text></xsl:when>
         <xsl:when test="$node/@name='Seek'"><xsl:text>SeekPoint</xsl:text></xsl:when>
         <xsl:when test="$node/@name='TagLanguage'"><xsl:value-of select="$node/@name" /></xsl:when>

--- a/spectool/schema_2_kaxsematic_h.xsl
+++ b/spectool/schema_2_kaxsematic_h.xsl
@@ -68,7 +68,7 @@ END_LIBMATROSKA_NAMESPACE
 </xsl:template>
   <xsl:template match="ebml:element">
     <!-- Ignore EBML extra constraints -->
-    <xsl:if test="@name!='Segment' and @name!='Cluster' and @name!='BlockGroup' and @name!='Block' and @name!='BlockVirtual' and @name!='ReferenceBlock' and @name!='SimpleBlock' and @name!='Cues' and @name!='CuePoint' and @name!='CueTrackPositions' and @name!='CueReference' and @name!='NextUID' and @name!='PrevUID' and @name!='SeekHead' and @name!='Seek' and @name!='TrackEntry'">
+    <xsl:if test="@name!='Segment' and @name!='Cluster' and @name!='BlockGroup' and @name!='Block' and @name!='BlockVirtual' and @name!='ReferenceBlock' and @name!='SimpleBlock' and @name!='Cues' and @name!='CuePoint' and @name!='CueTrackPositions' and @name!='CueReference' and @name!='NextUUID' and @name!='PrevUUID' and @name!='SeekHead' and @name!='Seek' and @name!='TrackEntry'">
     <!-- <xsl:copy> -->
 
         <xsl:variable name="minVer">
@@ -109,7 +109,7 @@ END_LIBMATROSKA_NAMESPACE
             <xsl:otherwise><xsl:value-of select="@name" /></xsl:otherwise>
         </xsl:choose>
         <xsl:text>)&#10;</xsl:text>
-        <xsl:if test="@name='SegmentUID'">
+        <xsl:if test="@name='SegmentUUID'">
             <xsl:text>#if defined(HAVE_EBML2) || defined(HAS_EBML2)&#10;</xsl:text>
             <xsl:text>public:&#10;</xsl:text>
             <xsl:text>  KaxSegmentUID(EBML_DEF_CONS EBML_DEF_SEP EBML_EXTRA_PARAM);&#10;</xsl:text>


### PR DESCRIPTION
Some element names changed.

Generates https://github.com/Matroska-Org/libmatroska/pull/61 properly (without v5 elements)