### PR TITLE
libmatroska2: add support for Matroska v5 reading/writing

### DIFF
--- a/libmatroska2/matroska2/matroska.h
+++ b/libmatroska2/matroska2/matroska.h
@@ -46,6 +46,7 @@
 #define PROFILE_MATROSKA_V2          (1<<1)
 #define PROFILE_MATROSKA_V3          (1<<2)
 #define PROFILE_MATROSKA_V4          (1<<5)
+#define PROFILE_MATROSKA_V5          (1<<6)
 #define PROFILE_WEBM                 (1<<3)
 #define PROFILE_DIVX                 (1<<4)
 #define PROFILE_MATROSKA_ALL        (PROFILE_MATROSKA_V1|PROFILE_MATROSKA_V2|PROFILE_MATROSKA_V3|PROFILE_MATROSKA_V4) 

--- a/libmatroska2/matroska2/matroska.h
+++ b/libmatroska2/matroska2/matroska.h
@@ -42,12 +42,12 @@
 #define CONTEXT_LIBMATROSKA_VERSION  0x00402
 
 // if a profile is set in ebml_semantic.DisabledProfile that means the element is not available for that profile
-#define PROFILE_MATROSKA_V1          1
-#define PROFILE_MATROSKA_V2          2
-#define PROFILE_MATROSKA_V3          4
-#define PROFILE_MATROSKA_V4          32
-#define PROFILE_WEBM                 8
-#define PROFILE_DIVX                16
+#define PROFILE_MATROSKA_V1          (1<<0)
+#define PROFILE_MATROSKA_V2          (1<<1)
+#define PROFILE_MATROSKA_V3          (1<<2)
+#define PROFILE_MATROSKA_V4          (1<<5)
+#define PROFILE_WEBM                 (1<<3)
+#define PROFILE_DIVX                 (1<<4)
 #define PROFILE_MATROSKA_ALL        (PROFILE_MATROSKA_V1|PROFILE_MATROSKA_V2|PROFILE_MATROSKA_V3|PROFILE_MATROSKA_V4) 
 #define PROFILE_MATROSKA_ANY        (PROFILE_MATROSKA_ALL|PROFILE_WEBM|PROFILE_DIVX) 
 

--- a/mkclean/mkclean.c
+++ b/mkclean/mkclean.c
@@ -124,7 +124,7 @@ typedef struct track_info
 
 static const tchar_t *GetProfileName(size_t ProfileNum)
 {
-static const tchar_t *Profile[7] = {T("unknown"), T("matroska v1"), T("matroska v2"), T("matroska v3"), T("webm"), T("matroska+DivX"), T("matroska v4")};
+static const tchar_t *Profile[8] = {T("unknown"), T("matroska v1"), T("matroska v2"), T("matroska v3"), T("webm"), T("matroska+DivX"), T("matroska v4"), T("matroska v5")};
 	switch (ProfileNum)
 	{
 	default:                  return Profile[0];
@@ -134,6 +134,7 @@ static const tchar_t *Profile[7] = {T("unknown"), T("matroska v1"), T("matroska 
 	case PROFILE_WEBM:        return Profile[4];
 	case PROFILE_DIVX:        return Profile[5];
 	case PROFILE_MATROSKA_V4: return Profile[6];
+	case PROFILE_MATROSKA_V5: return Profile[7];
 	}
 }
 
@@ -148,6 +149,7 @@ static int GetProfileId(int Profile)
 	case PROFILE_WEBM:        return 4;
 	case PROFILE_DIVX:        return 5;
 	case PROFILE_MATROSKA_V4: return 6;
+	case PROFILE_MATROSKA_V5: return 7;
 	}
 }
 
@@ -1482,6 +1484,8 @@ int main(int argc, const char *argv[])
 				DstProfile = PROFILE_DIVX;
 			else if (tcsisame_ascii(Path,T("6")))
 				DstProfile = PROFILE_MATROSKA_V4;
+			else if (tcsisame_ascii(Path,T("7")))
+				DstProfile = PROFILE_MATROSKA_V5;
 			else
 			{
 		        TextPrintf(StdErr,T("Unknown doctype %s\r\n"),Path);
@@ -1630,6 +1634,8 @@ int main(int argc, const char *argv[])
         SrcProfile = PROFILE_MATROSKA_V3;
     else if (SrcProfile==PROFILE_MATROSKA_V1 && DocVersion==4)
         SrcProfile = PROFILE_MATROSKA_V4;
+    else if (SrcProfile==PROFILE_MATROSKA_V1 && DocVersion==5)
+        SrcProfile = PROFILE_MATROSKA_V5;
 
 	if (!DstProfile)
 		DstProfile = SrcProfile;
@@ -1858,8 +1864,10 @@ int main(int argc, const char *argv[])
 		DocVersion=3;
 	if (DstProfile==PROFILE_MATROSKA_V4)
 		DocVersion=4;
+	if (DstProfile==PROFILE_MATROSKA_V5)
+		DocVersion=5;
 
-    if (ARRAYCOUNT(Alternate3DTracks, block_info*) && DstProfile!=PROFILE_MATROSKA_V3 && DstProfile!=PROFILE_MATROSKA_V4)
+    if (ARRAYCOUNT(Alternate3DTracks, block_info*) && DstProfile!=PROFILE_MATROSKA_V3 && DstProfile!=PROFILE_MATROSKA_V4 && DstProfile!=PROFILE_MATROSKA_V5)
     {
         TextPrintf(StdErr,T("Using --alt-3d in profile '%s' try \"--doctype %d\"\r\n"),GetProfileName(DstProfile),GetProfileId(PROFILE_MATROSKA_V3));
         goto exit;

--- a/mkclean/regression/mkcleanreg.py
+++ b/mkclean/regression/mkcleanreg.py
@@ -114,7 +114,7 @@ def main():
 
     i = 0
     for line in args.regression_file:
-        if not line.startswith('#'):
+        if not line.startswith('#') and not line.strip() == '':
             regression = line.split('\"')
             src_file = regression[1]
             mkclean_options = regression[3]

--- a/mkvalidator/mkvalidator.c
+++ b/mkvalidator/mkvalidator.c
@@ -113,7 +113,7 @@ void DebugMessage(const tchar_t* Msg,...)
 
 static const tchar_t *GetProfileName(size_t ProfileNum)
 {
-static const tchar_t *Profile[7] = {T("unknown"), T("matroska v1"), T("matroska v2"), T("matroska v3"), T("webm"), T("matroska+DivX"), T("matroska v4")};
+static const tchar_t *Profile[8] = {T("unknown"), T("matroska v1"), T("matroska v2"), T("matroska v3"), T("webm"), T("matroska+DivX"), T("matroska v4"), T("matroska v5")};
 	switch (ProfileNum)
 	{
 	default:                  return Profile[0];
@@ -123,6 +123,7 @@ static const tchar_t *Profile[7] = {T("unknown"), T("matroska v1"), T("matroska 
 	case PROFILE_WEBM:        return Profile[4];
 	case PROFILE_DIVX:        return Profile[5];
 	case PROFILE_MATROSKA_V4: return Profile[6];
+	case PROFILE_MATROSKA_V5: return Profile[7];
 	}
 }
 
@@ -1001,6 +1002,8 @@ int main(int argc, const char *argv[])
 	{
         if (DivX)
 			MatroskaProfile = PROFILE_DIVX;
+        else if (EL_Int(EbmlDocVer)==5)
+		    MatroskaProfile = PROFILE_MATROSKA_V5;
         else if (EL_Int(EbmlDocVer)==4)
 		    MatroskaProfile = PROFILE_MATROSKA_V4;
         else if (EL_Int(EbmlDocVer)==3)


### PR DESCRIPTION
In case some files with v5 DocTypeVersion appears we need to be able to validate (or invalidate) them.

~~Draft as it sits on top of #89~~