### PR TITLE
Generate libmatroska v1.x semantic separately

### DIFF
--- a/.github/workflows/libmatroska-semantic_1x.yaml
+++ b/.github/workflows/libmatroska-semantic_1x.yaml
@@ -1,0 +1,46 @@
+name: "libmatroska v1.x Semantic"
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # branches: [ master ]
+  schedule:
+    - cron: '44 16 * * 6'
+
+jobs:
+  xlst_generators:
+    name: Generate code from EBML Schema
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get pushed code
+        uses: actions/checkout@v3
+
+      - name: Get EBML Schema
+        run: curl -o ebml_matroska.xml https://raw.githubusercontent.com/ietf-wg-cellar/matroska-specification/master/ebml_matroska.xml
+
+      - name: Setup test tools
+        # we need the apt update because old packages won't load
+        run: |
+          sudo apt update
+          sudo apt install xsltproc
+
+      - name: Generate code
+        run: |
+          xsltproc -o _build/src/KaxSemantic.cpp       spectool/schema_2_kaxsemantic_cpp_1x.xsl ebml_matroska.xml
+          xsltproc -o _build/matroska/KaxSemantic.h    spectool/schema_2_kaxsemantic_h_1x.xsl   ebml_matroska.xml
+
+      - name: Get current libmatroska v1.x code
+        run: |
+          curl -o KaxSemantic.cpp https://raw.githubusercontent.com/Matroska-Org/libmatroska/v1.x/src/KaxSemantic.cpp
+          curl -o KaxSemantic.h   https://raw.githubusercontent.com/Matroska-Org/libmatroska/v1.x/matroska/KaxSemantic.h
+
+      - name: Generate libmatroska v1.x artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: libmatroska-semantic
+          path: _build
+
+      - name: Verify libmatroska semantic
+        run: |
+          diff -pur _build/matroska/KaxSemantic.h  KaxSemantic.h   || exit 1
+          diff -pur _build/src/KaxSemantic.cpp     KaxSemantic.cpp || exit 1

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![binaries](https://github.com/Matroska-Org/foundation-source/actions/workflows/generate-tools-bin.yaml/badge.svg)](https://github.com/Matroska-Org/foundation-source/actions/workflows/generate-tools-bin.yaml)
 [![libmatroska2 code](https://github.com/Matroska-Org/foundation-source/actions/workflows/libmatroska2-semantic.yaml/badge.svg)](https://github.com/Matroska-Org/foundation-source/actions/workflows/libmatroska2-semantic.yaml)
 [![libmatroska code](https://github.com/Matroska-Org/foundation-source/actions/workflows/libmatroska-semantic.yaml/badge.svg)](https://github.com/Matroska-Org/foundation-source/actions/workflows/libmatroska-semantic.yaml)
+[![libmatroska v1.x code](https://github.com/Matroska-Org/foundation-source/actions/workflows/libmatroska-semantic_1x.yaml/badge.svg)](https://github.com/Matroska-Org/foundation-source/actions/workflows/libmatroska-semantic_1x.yaml)
 
 libEBML2, libMatroska2, mkvalidator, mkclean and the specifications
 

--- a/spectool/schema_2_kaxsemantic_cpp_1x.xsl
+++ b/spectool/schema_2_kaxsemantic_cpp_1x.xsl
@@ -1,0 +1,498 @@
+<?xml version="1.0"?>
+<!--
+    File used to generate libmatroska KaxSemantic.cpp from ebml_matroska.xml 
+    Usage: xsltproc -o KaxSemantic.cpp schema_2_kaxsemantic_cpp.xsl ebml_matroska.xml
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" 
+    xmlns:str="http://exslt.org/strings"
+    exclude-result-prefixes="str xhtml ebml"
+    xmlns:xhtml="http://www.w3.org/1999/xhtml"
+    xmlns="urn:ietf:rfc:8794" xmlns:ebml="urn:ietf:rfc:8794">
+  <xsl:output encoding="UTF-8" method="text" version="1.0" indent="yes" />
+  <xsl:template match="ebml:EBMLSchema">/**********************************************************************
+**  DO NOT EDIT, GENERATED WITH schema_2_kaxsemantic_cpp.xsl
+**  https://github.com/Matroska-Org/foundation-source/tree/master/spectool
+**
+**  libmatroska : parse Matroska files, see https://www.matroska.org/
+**
+**  Copyright (c) 2002-2020, Matroska (non-profit organisation)
+**  All rights reserved.
+**
+** This file is part of libmatroska.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License as published by the Free Software Foundation; either
+** version 2.1 of the License, or (at your option) any later version.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+** Lesser General Public License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public
+** License along with this library; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+**
+** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
+** Contact license@matroska.org if any conditions of this licensing are
+** not clear to you.
+**
+**********************************************************************/
+
+#include "matroska/KaxContexts.h"
+#include "matroska/KaxSemantic.h"
+#include "matroska/KaxSegment.h"
+#include "matroska/KaxSeekHead.h"
+#include "matroska/KaxCluster.h"
+#include "matroska/KaxTracks.h"
+#include "matroska/KaxCues.h"
+#include "matroska/KaxInfoData.h"
+#include "matroska/KaxBlockData.h"
+#include "matroska/KaxCuesData.h"
+
+namespace libmatroska {
+<xsl:for-each select="ebml:element[not(starts-with(@path,'\EBML\'))]">
+    <!-- sorting messes the detection of the previous element MATROSKA_VERSION state -->
+    <!-- Maybe for each output we create we also create a counterpart call to check if the new MATROSKA_VERSION state that should be used -->
+    <!-- <xsl:sort select="translate(@path, '\+', '\')" /> -->
+    <xsl:apply-templates select="."/>
+</xsl:for-each>
+
+<xsl:for-each select="ebml:element[not(starts-with(@path,'\EBML\'))]">
+    <!-- sorting messes the detection of the previous element MATROSKA_VERSION state -->
+    <!-- Maybe for each output we create we also create a counterpart call to check if the new MATROSKA_VERSION state that should be used -->
+    <!-- <xsl:sort select="translate(@path, '\+', '\')" /> -->
+    <xsl:call-template name="output-blocked-render">
+        <xsl:with-param name="node" select="."/>
+    </xsl:call-template>
+</xsl:for-each>
+
+<!-- <xsl:apply-templates select="ebml:element">
+    <xsl:sort select="translate(@path, '\+', '\')" />
+</xsl:apply-templates> -->
+} // namespace libmatroska
+</xsl:template>
+  <xsl:template match="ebml:element">
+    <xsl:variable name="plainPath">
+        <xsl:value-of select="translate(@path, '\+', '\')" />
+    </xsl:variable>
+    <xsl:variable name="minVer">
+        <xsl:call-template name="get-min-ver">
+            <xsl:with-param name="node" select="."/>
+        </xsl:call-template>
+    </xsl:variable>
+        <!-- <xsl:if test="$minVer &gt; 1 or ebml:extension[@divx='1']">
+            <xsl:text>#if MATROSKA_VERSION >= 2&#10;</xsl:text>
+        </xsl:if> -->
+        <xsl:choose>
+            <xsl:when test="@type='master'">
+                <xsl:text>&#10;DEFINE_START_SEMANTIC(Kax</xsl:text>
+                <xsl:choose>
+                    <xsl:when test="ebml:extension[@cppname]"><xsl:value-of select="ebml:extension[@cppname][1]/@cppname" /></xsl:when>
+                    <xsl:otherwise><xsl:value-of select="@name" /></xsl:otherwise>
+                </xsl:choose>
+                <xsl:text>)&#10;</xsl:text>
+                <xsl:variable name="masterMinVer">
+                    <xsl:value-of select="$minVer" />
+                </xsl:variable>
+<!-- <xsl:value-of select="$masterMinVer" /><xsl:text>&#10;</xsl:text> -->
+
+                <xsl:if test="@recursive=1">
+                    <xsl:call-template name="outputContextTableItem">
+                        <xsl:with-param name="node" select="."/>
+                        <xsl:with-param name="inMinver" select="$masterMinVer"/>
+                        <xsl:with-param name="asRecursive" select="1"/>
+                    </xsl:call-template>
+                </xsl:if>
+                <xsl:for-each select="/ebml:EBMLSchema/ebml:element[translate(@path, '\+', '\') = concat(concat($plainPath, '\'), @name)]">
+                    <xsl:call-template name="outputContextTableItem">
+                        <xsl:with-param name="node" select="."/>
+                        <xsl:with-param name="inMinver" select="$masterMinVer"/>
+                    </xsl:call-template>
+                </xsl:for-each>
+                <xsl:text>DEFINE_END_SEMANTIC(Kax</xsl:text>
+                <xsl:choose>
+                    <xsl:when test="ebml:extension[@cppname]"><xsl:value-of select="ebml:extension[@cppname][1]/@cppname" /></xsl:when>
+                    <xsl:otherwise><xsl:value-of select="@name" /></xsl:otherwise>
+                </xsl:choose>
+                <xsl:text>)&#10;&#10;</xsl:text>
+
+                <xsl:text>DEFINE_MKX_MASTER</xsl:text>
+                <xsl:if test="not(contains(substring($plainPath,2),'\'))"><xsl:text>_ORPHAN</xsl:text></xsl:if>
+                <!-- Needs a special constructor -->
+                <xsl:if test="@name='Attachments' or @name='AttachedFile' or @name='Cluster' or @name='BlockGroup' or @name='TrackEntry'"><xsl:text>_CONS</xsl:text></xsl:if>
+                <xsl:text>(Kax</xsl:text>
+                <xsl:choose>
+                    <xsl:when test="ebml:extension[@cppname]"><xsl:value-of select="ebml:extension[@cppname][1]/@cppname" /></xsl:when>
+                    <xsl:otherwise><xsl:value-of select="@name" /></xsl:otherwise>
+                </xsl:choose>
+                <xsl:text>, </xsl:text>
+                <xsl:value-of select="@id" /><xsl:text>, </xsl:text>
+                <xsl:value-of select="((string-length(@id) - 2) * 0.5)" /> 
+                <xsl:choose>
+                    <xsl:when test="not(contains(substring($plainPath,2),'\'))" />
+                    <xsl:otherwise>
+                        <xsl:text>, Kax</xsl:text>
+                        <xsl:call-template name="output-master-parent">
+                            <xsl:with-param name="node" select="."/>
+                        </xsl:call-template>
+                    </xsl:otherwise>
+                </xsl:choose>
+                <xsl:call-template name="output-display-name">
+                    <xsl:with-param name="node" select="."/>
+                </xsl:call-template>
+                <xsl:text>)&#10;</xsl:text>
+                
+            </xsl:when>
+            <xsl:when test="@type='binary'">
+                
+                <xsl:text>DEFINE_MKX_BINARY</xsl:text>
+                <xsl:choose>
+                    <!-- Needs a special constructor -->
+                    <xsl:when test="@name='Block' or @name='SimpleBlock' or @name='BlockVirtual' or @name='NextUUID' or @name='PrevUUID'"><xsl:text>_CONS</xsl:text></xsl:when>
+                    <xsl:otherwise><xsl:text> </xsl:text></xsl:otherwise>
+                </xsl:choose>
+                <xsl:text>(Kax</xsl:text>
+                <xsl:choose>
+                    <xsl:when test="ebml:extension[@cppname]"><xsl:value-of select="ebml:extension[@cppname][1]/@cppname" /></xsl:when>
+                    <xsl:otherwise><xsl:value-of select="@name" /></xsl:otherwise>
+                </xsl:choose>
+                <xsl:text>, </xsl:text>
+                <xsl:value-of select="@id" /><xsl:text>, </xsl:text>
+                <xsl:value-of select="((string-length(@id) - 2) * 0.5)" /> 
+                <xsl:text>, Kax</xsl:text>
+                <xsl:call-template name="output-master-parent">
+                    <xsl:with-param name="node" select="."/>
+                </xsl:call-template>
+                <xsl:call-template name="output-display-name">
+                    <xsl:with-param name="node" select="."/>
+                </xsl:call-template>
+                <xsl:text>)&#10;</xsl:text>
+                
+            </xsl:when>
+            <xsl:when test="@type='uinteger'">
+                
+                <xsl:text>DEFINE_MKX_UINTEGER</xsl:text>
+                <xsl:if test="@default and (number(@default)=number(@default))"><xsl:text>_DEF</xsl:text></xsl:if>
+                <xsl:text>(Kax</xsl:text>
+                <xsl:choose>
+                    <xsl:when test="ebml:extension[@cppname]"><xsl:value-of select="ebml:extension[@cppname][1]/@cppname" /></xsl:when>
+                    <xsl:otherwise><xsl:value-of select="@name" /></xsl:otherwise>
+                </xsl:choose>
+                <xsl:text>, </xsl:text>
+                <xsl:value-of select="@id" /><xsl:text>, </xsl:text>
+                <xsl:value-of select="((string-length(@id) - 2) * 0.5)" /> 
+                <xsl:text>, Kax</xsl:text>
+                <xsl:call-template name="output-master-parent">
+                    <xsl:with-param name="node" select="."/>
+                </xsl:call-template>
+                <xsl:call-template name="output-display-name">
+                    <xsl:with-param name="node" select="."/>
+                </xsl:call-template>
+                <xsl:if test="@default and (number(@default)=number(@default))"><xsl:text>, </xsl:text><xsl:value-of select="@default" /></xsl:if>
+                <xsl:text>)&#10;</xsl:text>
+                
+            </xsl:when>
+            <xsl:when test="@type='integer'">
+                
+                <xsl:text>DEFINE_MKX_SINTEGER</xsl:text>
+                <xsl:if test="@default and (number(@default)=number(@default))"><xsl:text>_DEF</xsl:text></xsl:if>
+                <!-- Needs a special constructor -->
+                <xsl:if test="@name='ReferenceBlock'"><xsl:text>_CONS</xsl:text></xsl:if>
+                <xsl:text>(Kax</xsl:text>
+                <xsl:choose>
+                    <xsl:when test="ebml:extension[@cppname]"><xsl:value-of select="ebml:extension[@cppname][1]/@cppname" /></xsl:when>
+                    <xsl:otherwise><xsl:value-of select="@name" /></xsl:otherwise>
+                </xsl:choose>
+                <xsl:text>, </xsl:text>
+                <xsl:value-of select="@id" /><xsl:text>, </xsl:text>
+                <xsl:value-of select="((string-length(@id) - 2) * 0.5)" /> 
+                <xsl:text>, Kax</xsl:text>
+                <xsl:call-template name="output-master-parent">
+                    <xsl:with-param name="node" select="."/>
+                </xsl:call-template>
+                <xsl:call-template name="output-display-name">
+                    <xsl:with-param name="node" select="."/>
+                </xsl:call-template>
+                <xsl:if test="@default and (number(@default)=number(@default))"><xsl:text>, </xsl:text><xsl:value-of select="@default" /></xsl:if>
+                <xsl:text>)&#10;</xsl:text>
+                
+            </xsl:when>
+            <xsl:when test="@type='utf-8'">
+                
+                <xsl:text>DEFINE_MKX_UNISTRING</xsl:text>
+                <xsl:if test="@default"><xsl:text>_DEF</xsl:text></xsl:if>
+                <xsl:text>(Kax</xsl:text>
+                <xsl:choose>
+                    <xsl:when test="ebml:extension[@cppname]"><xsl:value-of select="ebml:extension[@cppname][1]/@cppname" /></xsl:when>
+                    <xsl:otherwise><xsl:value-of select="@name" /></xsl:otherwise>
+                </xsl:choose>
+                <xsl:text>, </xsl:text>
+                <xsl:value-of select="@id" /><xsl:text>, </xsl:text>
+                <xsl:value-of select="((string-length(@id) - 2) * 0.5)" /> 
+                <xsl:text>, Kax</xsl:text>
+                <xsl:call-template name="output-master-parent">
+                    <xsl:with-param name="node" select="."/>
+                </xsl:call-template>
+                <xsl:call-template name="output-display-name">
+                    <xsl:with-param name="node" select="."/>
+                </xsl:call-template>
+                <xsl:if test="@default"><xsl:text>, "</xsl:text><xsl:value-of select="@default" />"</xsl:if>
+                <xsl:text>)&#10;</xsl:text>
+                
+            </xsl:when>
+            <xsl:when test="@type='string'">
+                
+                <xsl:text>DEFINE_MKX_STRING</xsl:text>
+                <xsl:if test="@default"><xsl:text>_DEF</xsl:text></xsl:if>
+                <xsl:text>(Kax</xsl:text>
+                <xsl:choose>
+                    <xsl:when test="ebml:extension[@cppname]"><xsl:value-of select="ebml:extension[@cppname][1]/@cppname" /></xsl:when>
+                    <xsl:otherwise><xsl:value-of select="@name" /></xsl:otherwise>
+                </xsl:choose>
+                <xsl:text>, </xsl:text>
+                <xsl:value-of select="@id" /><xsl:text>, </xsl:text>
+                <xsl:value-of select="((string-length(@id) - 2) * 0.5)" /> 
+                <xsl:text>, Kax</xsl:text>
+                <xsl:call-template name="output-master-parent">
+                    <xsl:with-param name="node" select="."/>
+                </xsl:call-template>
+                <xsl:call-template name="output-display-name">
+                    <xsl:with-param name="node" select="."/>
+                </xsl:call-template>
+                <xsl:if test="@default"><xsl:text>, "</xsl:text><xsl:value-of select="@default" /><xsl:text>"</xsl:text></xsl:if>
+                <xsl:text>)&#10;</xsl:text>
+                
+            </xsl:when>
+            <xsl:when test="@type='float'">
+                
+                <xsl:text>DEFINE_MKX_FLOAT</xsl:text>
+                <xsl:if test="@default and starts-with(@default,'0x')"><xsl:text>_DEF</xsl:text></xsl:if>
+                <xsl:text>(Kax</xsl:text>
+                <xsl:choose>
+                    <xsl:when test="ebml:extension[@cppname]"><xsl:value-of select="ebml:extension[@cppname][1]/@cppname" /></xsl:when>
+                    <xsl:otherwise><xsl:value-of select="@name" /></xsl:otherwise>
+                </xsl:choose>
+                <xsl:text>, </xsl:text>
+                <xsl:value-of select="@id" /><xsl:text>, </xsl:text>
+                <xsl:value-of select="((string-length(@id) - 2) * 0.5)" /> 
+                <xsl:text>, Kax</xsl:text>
+                <xsl:call-template name="output-master-parent">
+                    <xsl:with-param name="node" select="."/>
+                </xsl:call-template>
+                <xsl:call-template name="output-display-name">
+                    <xsl:with-param name="node" select="."/>
+                </xsl:call-template>
+                <xsl:if test="@default and starts-with(@default,'0x')">
+                    <xsl:choose>
+                        <xsl:when test="@default='0x1p+0'">, 1</xsl:when>
+                        <xsl:when test="@default='0x0p+0'">, 0</xsl:when>
+                        <xsl:when test="@default='0x1.f4p+12'">, 8000</xsl:when>
+                        <xsl:otherwise><xsl:text>, </xsl:text><xsl:value-of select="@default" /></xsl:otherwise>>
+                    </xsl:choose>
+                </xsl:if>
+                <xsl:text>)&#10;</xsl:text>
+                
+            </xsl:when>
+            <xsl:when test="@type='date'">
+                <xsl:text>DEFINE_MKX_DATE</xsl:text>
+                <xsl:choose>
+                    <xsl:when test="@default and (number(@default)=number(@default))"><xsl:text>_DEF</xsl:text></xsl:when>
+                    <xsl:otherwise><xsl:text>    </xsl:text></xsl:otherwise>
+                </xsl:choose>
+                <xsl:text>(Kax</xsl:text>
+                <xsl:choose>
+                    <xsl:when test="ebml:extension[@cppname]"><xsl:value-of select="ebml:extension[@cppname][1]/@cppname" /></xsl:when>
+                    <xsl:otherwise><xsl:value-of select="@name" /></xsl:otherwise>
+                </xsl:choose>
+                <xsl:text>, </xsl:text>
+                <xsl:value-of select="@id" /><xsl:text>, </xsl:text>
+                <xsl:value-of select="((string-length(@id) - 2) * 0.5)" /> 
+                <xsl:text>, Kax</xsl:text>
+                <xsl:call-template name="output-master-parent">
+                    <xsl:with-param name="node" select="."/>
+                </xsl:call-template>
+                <xsl:call-template name="output-display-name">
+                    <xsl:with-param name="node" select="."/>
+                </xsl:call-template>
+                <xsl:if test="@default and (number(@default)=number(@default))"><xsl:text>, </xsl:text><xsl:value-of select="@default" /></xsl:if>
+                <xsl:text>)&#10;</xsl:text>
+            </xsl:when>
+        </xsl:choose>
+
+
+        <!-- <xsl:if test="$minVer &gt; 1 or ebml:extension[@divx='1']">
+            <xsl:text>#endif&#10;</xsl:text>
+        </xsl:if> -->
+    <!-- </xsl:copy> -->
+    <!-- </xsl:if> -->
+  </xsl:template>
+
+  <xsl:template name="outputContextTableItem">
+    <xsl:param name="node"/>
+    <xsl:param name="asRecursive"/>
+    <xsl:param name="inMinver"/>
+
+    <xsl:variable name="minVer">
+        <xsl:call-template name="get-min-ver">
+            <xsl:with-param name="node" select="$node"/>
+        </xsl:call-template>
+    </xsl:variable>
+
+    <!-- <xsl:if test="$minVer &gt; 1 or ebml:extension[@divx='1']">
+        <xsl:text>#if MATROSKA_VERSION >= 2&#10;</xsl:text>
+    </xsl:if> -->
+    <xsl:text>DEFINE_SEMANTIC_ITEM(</xsl:text>
+    <xsl:choose>
+        <xsl:when test="$asRecursive=1"><xsl:text>false</xsl:text></xsl:when>
+        <xsl:when test="$node/@minOccurs!='' and $node/@minOccurs!='0'"><xsl:text>true</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>false</xsl:text></xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>, </xsl:text>
+    <xsl:choose>
+        <xsl:when test="$node/@recurring='1'"><xsl:text>false</xsl:text></xsl:when>
+        <xsl:when test="$node/@maxOccurs='1'"><xsl:text>true</xsl:text></xsl:when>
+        <xsl:otherwise><xsl:text>false</xsl:text></xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>, Kax</xsl:text>
+    <xsl:choose>
+        <xsl:when test="ebml:extension[@cppname]"><xsl:value-of select="ebml:extension[@cppname][1]/@cppname" /></xsl:when>
+        <xsl:otherwise><xsl:value-of select="$node/@name" /></xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>)</xsl:text>
+    <xsl:if test="$asRecursive=1"><xsl:text> // recursive</xsl:text></xsl:if>
+    <xsl:if test="$node/@maxver='0'">
+        <xsl:choose>
+            <xsl:when test="ebml:extension[@divx='1']"><xsl:text> // DivX specific</xsl:text></xsl:when>
+            <xsl:otherwise><xsl:text> // not supported</xsl:text></xsl:otherwise>
+        </xsl:choose>
+    </xsl:if>
+    <xsl:text>&#10;</xsl:text>
+    <!-- <xsl:if test="$minVer &gt; 1 or ebml:extension[@divx='1']">
+        <xsl:text>#endif // MATROSKA_VERSION&#10;</xsl:text>
+    </xsl:if> -->
+  </xsl:template>
+
+
+  <xsl:template match="documentation">
+    <documentation>
+        <xsl:attribute name="lang"><xsl:value-of select="@lang" /></xsl:attribute>
+        <xsl:if test="@type">
+            <xsl:attribute name="type"><xsl:value-of select="@type" /></xsl:attribute>
+        </xsl:if>
+        <!-- <xsl:attribute name="type">
+            <xsl:choose>
+                <xsl:when test="@type">
+                    <xsl:value-of select="@type"/>
+                </xsl:when>
+                <xsl:otherwise>documentation</xsl:otherwise>
+            </xsl:choose>
+        </xsl:attribute> -->
+        <!-- make sure the links are kept -->
+        <xsl:apply-templates/>
+    </documentation>
+  </xsl:template>
+
+  <!-- HTML tags found in documentation -->
+  <xsl:template match="a">
+    <a href="{@href}"><xsl:apply-templates/></a>
+  </xsl:template>
+  <xsl:template match="strong">
+    <strong><xsl:apply-templates/></strong>
+  </xsl:template>
+  <xsl:template match="br">
+    <br/><xsl:apply-templates/>
+  </xsl:template>
+
+  <xsl:template match="comment()">
+    <xsl:comment>
+      <xsl:value-of select="."/>
+    </xsl:comment>
+  </xsl:template>
+
+  <xsl:template name="output-blocked-render">
+    <xsl:param name="node"/>
+
+    <xsl:if test="$node/@maxver='0' or $node/@maxver='1' or $node/@maxver='2' or $node/@maxver='3'">
+        <xsl:text>&#10;filepos_t Kax</xsl:text>
+        <xsl:choose>
+            <xsl:when test="ebml:extension[@cppname]"><xsl:value-of select="ebml:extension[@cppname][1]/@cppname" /></xsl:when>
+            <xsl:otherwise><xsl:value-of select="$node/@name" /></xsl:otherwise>
+        </xsl:choose>
+        <xsl:text>::RenderData(IOCallback &amp; /* output */, bool /* bForceRender */, bool /* bSaveDefault */) {&#10;</xsl:text>
+        <xsl:text>  assert(false); // no you are not allowed to use this element !&#10;</xsl:text>
+        <xsl:text>  return 0;&#10;</xsl:text>
+        <xsl:text>}&#10;</xsl:text>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template name="output-master-parent">
+    <xsl:param name="node"/>
+
+    <xsl:variable name="findName">
+        <xsl:choose>
+            <xsl:when test="$node/@recursive=1"><xsl:text>+</xsl:text><xsl:value-of select="$node/@name"/></xsl:when>
+            <xsl:otherwise><xsl:value-of select="$node/@name"/></xsl:otherwise>
+        </xsl:choose>
+    </xsl:variable>
+
+    <xsl:for-each select="/ebml:EBMLSchema/ebml:element[$node/@path = concat(concat(@path, '\'), $findName)]">
+        <xsl:choose>
+            <xsl:when test="ebml:extension[@cppname]"><xsl:value-of select="ebml:extension[@cppname][1]/@cppname" /></xsl:when>
+            <xsl:otherwise><xsl:value-of select="@name" /></xsl:otherwise>
+        </xsl:choose>
+    </xsl:for-each>
+  </xsl:template>
+
+  <xsl:template name="get-min-ver">
+    <xsl:param name="node"/>
+    <xsl:choose>
+        <xsl:when test="$node/@name='EncryptedBlock'">2</xsl:when>
+        <xsl:when test="$node/@name='BlockVirtual'">2</xsl:when>
+        <xsl:when test="$node/@name='ReferenceVirtual'">2</xsl:when>
+        <xsl:when test="$node/@name='FrameNumber'">2</xsl:when>
+        <xsl:when test="$node/@name='BlockAdditionID'">2</xsl:when>
+        <xsl:when test="$node/@name='Delay'">2</xsl:when>
+        <xsl:when test="$node/@name='SliceDuration'">2</xsl:when>
+        <xsl:when test="$node/@name='TrackOffset'">2</xsl:when>
+        <xsl:when test="$node/@name='CodecSettings'">2</xsl:when>
+        <xsl:when test="$node/@name='CodecInfoURL'">2</xsl:when>
+        <xsl:when test="$node/@name='CodecDownloadURL'">2</xsl:when>
+        <xsl:when test="$node/@name='OldStereoMode'">2</xsl:when>
+        <xsl:when test="$node/@name='GammaValue'">2</xsl:when>
+        <xsl:when test="$node/@name='FrameRate'">2</xsl:when>
+        <xsl:when test="$node/@name='ChannelPositions'">2</xsl:when>
+        <xsl:when test="$node/@name='CueRefCluster'">2</xsl:when>
+        <xsl:when test="$node/@name='CueRefNumber'">2</xsl:when>
+        <xsl:when test="$node/@name='CueRefCodecState'">2</xsl:when>
+        <xsl:otherwise><xsl:value-of select="$node/@minver" /></xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+
+  <xsl:template name="output-display-name">
+    <xsl:param name="node"/>
+
+    <xsl:text>, "</xsl:text>
+<!-- <xsl:value-of select="ebml:extension[$node/@cppname][1]/@cppname" /><xsl:text>/ </xsl:text>
+<xsl:value-of select="ebml:extension[@cppname][1]/@cppname" /><xsl:text>/ </xsl:text> -->
+    <xsl:choose>
+        <xsl:when test="$node/@name='AttachedFile'"><xsl:value-of select="$node/@name" /></xsl:when>
+        <xsl:when test="$node/@name='FileMediaType'"><xsl:text>FileMimeType</xsl:text></xsl:when>
+        <xsl:when test="$node/@name='SeekHead'"><xsl:text>SeekHeader</xsl:text></xsl:when>
+        <xsl:when test="$node/@name='Seek'"><xsl:text>SeekPoint</xsl:text></xsl:when>
+        <xsl:when test="$node/@name='TagLanguage'"><xsl:value-of select="$node/@name" /></xsl:when>
+        <xsl:when test="$node/@name='ReferencePriority'"><xsl:text>FlagReferenced</xsl:text></xsl:when>
+        <xsl:when test="ebml:extension[@cppname]"><xsl:value-of select="ebml:extension[@cppname][1]/@cppname" /></xsl:when>
+        <xsl:otherwise><xsl:value-of select="$node/@name" /></xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>"</xsl:text>
+  </xsl:template>
+
+  <xsl:template match="@* | node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@* | node()"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/spectool/schema_2_kaxsemantic_h_1x.xsl
+++ b/spectool/schema_2_kaxsemantic_h_1x.xsl
@@ -1,0 +1,556 @@
+<?xml version="1.0"?>
+<!--
+    File used to generate libmatroska KaxSemantic.h from ebml_matroska.xml 
+    Usage: xsltproc -o KaxSemantic.h schema_2_kaxsemantic_h.xsl ebml_matroska.xml
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="1.0" 
+    xmlns:str="http://exslt.org/strings"
+    exclude-result-prefixes="str xhtml ebml"
+    xmlns:xhtml="http://www.w3.org/1999/xhtml"
+    xmlns="urn:ietf:rfc:8794" xmlns:ebml="urn:ietf:rfc:8794">
+  <xsl:output encoding="UTF-8" method="text" version="1.0" indent="yes" />
+  <xsl:template match="ebml:EBMLSchema">/**********************************************************************
+**  DO NOT EDIT, GENERATED WITH DATA2LIB
+**  https://github.com/Matroska-Org/foundation-source/tree/master/spectool
+**
+**  libmatroska : parse Matroska files, see https://www.matroska.org/
+**
+**  Copyright (c) 2002-2022, Matroska (non-profit organisation)
+**  All rights reserved.
+**
+** This file is part of libmatroska.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License as published by the Free Software Foundation; either
+** version 2.1 of the License, or (at your option) any later version.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+** Lesser General Public License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public
+** License along with this library; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+**
+** See http://www.gnu.org/licenses/lgpl-2.1.html for LGPL licensing information.**
+** Contact license@matroska.org if any conditions of this licensing are
+** not clear to you.
+**
+**********************************************************************/
+
+
+#ifndef LIBMATROSKA_SEMANTIC_H
+#define LIBMATROSKA_SEMANTIC_H
+
+#include "matroska/KaxTypes.h"
+#include &lt;ebml/EbmlUInteger.h&gt;
+#include &lt;ebml/EbmlSInteger.h&gt;
+#include &lt;ebml/EbmlDate.h&gt;
+#include &lt;ebml/EbmlFloat.h&gt;
+#include &lt;ebml/EbmlString.h&gt;
+#include &lt;ebml/EbmlUnicodeString.h&gt;
+#include &lt;ebml/EbmlBinary.h&gt;
+#include &lt;ebml/EbmlMaster.h&gt;
+#include "matroska/KaxDefines.h"
+
+using namespace libebml;
+
+namespace libmatroska {
+<xsl:for-each select="ebml:element[not(starts-with(@path,'\EBML\'))]">
+    <!-- <xsl:sort select="translate(@path, '\+', '\')" /> -->
+    <xsl:apply-templates select="."/>
+</xsl:for-each>
+
+<xsl:for-each select="ebml:element">
+    <xsl:sort select="not(@name='TrackType')"/>
+    <xsl:sort select="not(@name='ContentCompAlgo')"/>
+
+    <!-- Output the enums after the IDs -->
+    <xsl:call-template name="outputAllEnums"/>
+</xsl:for-each>
+} // namespace libmatroska
+
+#endif // LIBMATROSKA_SEMANTIC_H
+</xsl:template>
+  <xsl:template match="ebml:element">
+    <!-- Ignore EBML extra constraints -->
+    <xsl:if test="@name!='Segment' and @name!='Cluster' and @name!='BlockGroup' and @name!='Block' and @name!='BlockVirtual' and @name!='ReferenceBlock' and @name!='SimpleBlock' and @name!='Cues' and @name!='CuePoint' and @name!='CueTrackPositions' and @name!='CueReference' and @name!='NextUUID' and @name!='PrevUUID' and @name!='SeekHead' and @name!='Seek' and @name!='TrackEntry'">
+    <!-- <xsl:copy> -->
+
+        <xsl:variable name="minVer">
+            <xsl:call-template name="get-min-ver">
+                <xsl:with-param name="node" select="."/>
+            </xsl:call-template>
+        </xsl:variable>
+
+        <!-- <xsl:if test="$minVer &gt; 1 or ebml:extension[@divx='1']">#if MATROSKA_VERSION >= 2&#10;</xsl:if> -->
+        <xsl:choose>
+            <xsl:when test="@type='master'">
+                <xsl:text>DECLARE_MKX_MASTER(Kax</xsl:text>
+            </xsl:when>
+            <xsl:when test="@type='binary'">
+                <xsl:text>DECLARE_MKX_BINARY (Kax</xsl:text>
+            </xsl:when>
+            <xsl:when test="@type='uinteger'">
+                <xsl:text>DECLARE_MKX_UINTEGER(Kax</xsl:text>
+            </xsl:when>
+            <xsl:when test="@type='integer'">
+                <xsl:text>DECLARE_MKX_SINTEGER(Kax</xsl:text>
+            </xsl:when>
+            <xsl:when test="@type='utf-8'">
+                <xsl:text>DECLARE_MKX_UNISTRING(Kax</xsl:text>
+            </xsl:when>
+            <xsl:when test="@type='string'">
+                <xsl:text>DECLARE_MKX_STRING(Kax</xsl:text>
+            </xsl:when>
+            <xsl:when test="@type='float'">
+                <xsl:text>DECLARE_MKX_FLOAT(Kax</xsl:text>
+            </xsl:when>
+            <xsl:when test="@type='date'">
+                <xsl:text>DECLARE_MKX_DATE    (Kax</xsl:text>
+            </xsl:when>
+        </xsl:choose>
+        <xsl:choose>
+            <xsl:when test="ebml:extension[@cppname]"><xsl:value-of select="ebml:extension[@cppname][1]/@cppname" /></xsl:when>
+            <xsl:otherwise><xsl:value-of select="@name" /></xsl:otherwise>
+        </xsl:choose>
+        <xsl:text>)&#10;</xsl:text>
+        <xsl:if test="@name='SegmentUUID'">
+            <xsl:text>#if defined(HAVE_EBML2) || defined(HAS_EBML2)&#10;</xsl:text>
+            <xsl:text>public:&#10;</xsl:text>
+            <xsl:text>  KaxSegmentUID(EBML_DEF_CONS EBML_DEF_SEP EBML_EXTRA_PARAM);&#10;</xsl:text>
+            <xsl:text>#endif&#10;</xsl:text>
+        </xsl:if>
+        <xsl:if test="@maxver='0' or @maxver='1' or @maxver='2' or @maxver='3' or @length">
+            <xsl:text>public:&#10;</xsl:text>
+        </xsl:if>
+        <xsl:if test="@maxver='0' or @maxver='1' or @maxver='2' or @maxver='3'">
+            <xsl:text>  filepos_t RenderData(IOCallback &amp; output, bool bForceRender, bool bSaveDefault) override;&#10;</xsl:text>
+        </xsl:if>
+        <xsl:if test="@length">
+            <xsl:text>  bool ValidateSize() const override {return IsFiniteSize() &amp;&amp; GetSize() </xsl:text>
+            <xsl:choose>
+                <xsl:when test="contains(@length, '=') or contains(@length, '&lt;') or contains(@length, '&gt;')"><xsl:value-of select="@length"/></xsl:when>
+                <xsl:otherwise><xsl:text>== </xsl:text><xsl:value-of select="@length"/></xsl:otherwise>
+            </xsl:choose>
+            <xsl:text>;}&#10;</xsl:text>
+        </xsl:if>
+        <xsl:text>};&#10;</xsl:text>
+        <!-- <xsl:if test="$minVer &gt; 1 or ebml:extension[@divx='1']">#endif&#10;</xsl:if> -->
+        <xsl:text>&#10;</xsl:text>
+    <!-- </xsl:copy> -->
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template name="get-min-ver">
+    <xsl:param name="node"/>
+    <xsl:choose>
+        <xsl:when test="$node/@name='EncryptedBlock'">2</xsl:when>
+        <xsl:when test="$node/@name='BlockVirtual'">2</xsl:when>
+        <xsl:when test="$node/@name='ReferenceVirtual'">2</xsl:when>
+        <xsl:when test="$node/@name='FrameNumber'">2</xsl:when>
+        <xsl:when test="$node/@name='BlockAdditionID'">2</xsl:when>
+        <xsl:when test="$node/@name='Delay'">2</xsl:when>
+        <xsl:when test="$node/@name='SliceDuration'">2</xsl:when>
+        <xsl:when test="$node/@name='TrackOffset'">2</xsl:when>
+        <xsl:when test="$node/@name='CodecSettings'">2</xsl:when>
+        <xsl:when test="$node/@name='CodecInfoURL'">2</xsl:when>
+        <xsl:when test="$node/@name='CodecDownloadURL'">2</xsl:when>
+        <xsl:when test="$node/@name='OldStereoMode'">2</xsl:when>
+        <xsl:when test="$node/@name='GammaValue'">2</xsl:when>
+        <xsl:when test="$node/@name='FrameRate'">2</xsl:when>
+        <xsl:when test="$node/@name='ChannelPositions'">2</xsl:when>
+        <xsl:when test="$node/@name='CueRefCluster'">2</xsl:when>
+        <xsl:when test="$node/@name='CueRefNumber'">2</xsl:when>
+        <xsl:when test="$node/@name='CueRefCodecState'">2</xsl:when>
+        <xsl:otherwise><xsl:value-of select="$node/@minver" /></xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="documentation">
+    <documentation>
+        <xsl:attribute name="lang"><xsl:value-of select="@lang" /></xsl:attribute>
+        <xsl:if test="@type">
+            <xsl:attribute name="type"><xsl:value-of select="@type" /></xsl:attribute>
+        </xsl:if>
+        <!-- <xsl:attribute name="type">
+            <xsl:choose>
+                <xsl:when test="@type">
+                    <xsl:value-of select="@type"/>
+                </xsl:when>
+                <xsl:otherwise>documentation</xsl:otherwise>
+            </xsl:choose>
+        </xsl:attribute> -->
+        <!-- make sure the links are kept -->
+        <xsl:apply-templates/>
+    </documentation>
+  </xsl:template>
+
+
+    <!-- Enum output -->
+    <xsl:template name="ConvertDecToHex">
+        <xsl:param name="index" />
+        <xsl:if test="$index > 0">
+        <xsl:call-template name="ConvertDecToHex">
+            <xsl:with-param name="index" select="floor($index div 16)" />
+        </xsl:call-template>
+        <xsl:choose>
+            <xsl:when test="$index mod 16 &lt; 10">
+                <xsl:value-of select="$index mod 16" />
+            </xsl:when>
+            <xsl:otherwise>
+            <xsl:choose>
+                <xsl:when test="$index mod 16 = 10">A</xsl:when>
+                <xsl:when test="$index mod 16 = 11">B</xsl:when>
+                <xsl:when test="$index mod 16 = 12">C</xsl:when>
+                <xsl:when test="$index mod 16 = 13">D</xsl:when>
+                <xsl:when test="$index mod 16 = 14">E</xsl:when>
+                <xsl:when test="$index mod 16 = 15">F</xsl:when>
+                <xsl:otherwise>A</xsl:otherwise>
+            </xsl:choose>
+            </xsl:otherwise>
+        </xsl:choose>
+        </xsl:if>
+    </xsl:template>
+
+    <xsl:template name="ConvertToHex">
+        <xsl:param name="index" />
+        <xsl:text>0x</xsl:text>
+        <xsl:call-template name="ConvertDecToHex">
+            <xsl:with-param name="index" select="$index" />
+        </xsl:call-template>
+    </xsl:template>
+
+    <xsl:template name="outputAllEnums">
+        <xsl:if test="ebml:restriction/ebml:enum and @type!='string'">
+            <xsl:variable name="prefix">
+                <xsl:choose>
+                    <xsl:when test="@name='ContentCompAlgo'">TRACK_ENCODING_COMP</xsl:when>
+                    <xsl:when test="@name='TrackType'">TRACK_TYPE</xsl:when>
+                    <!-- <xsl:when test="@name='ProjectionType'">VIDEO_PROJECTION_TYPE</xsl:when>
+                    <xsl:when test="@name='FlagInterlaced'">VIDEO_INTERLACE_FLAG</xsl:when> -->
+                    <xsl:when test="@name='StereoMode'">VIDEO_STEREO</xsl:when>
+                    <xsl:when test="@name='DisplayUnit'">DISPLAY_UNIT</xsl:when>
+                    <xsl:when test="@name='TransferCharacteristics'">TRANSFER</xsl:when>
+                    <xsl:when test="@name='TargetTypeValue'">TARGET_TYPE</xsl:when>
+                    <!-- <xsl:when test="contains(@path,'\TrackEntry\Video\Colour\')"><xsl:text>COLOUR_</xsl:text><xsl:value-of select="@name"/></xsl:when> -->
+                    <xsl:when test="contains(@path,'\TrackEntry\Video\')"><xsl:text>VIDEO_</xsl:text><xsl:value-of select="@name"/></xsl:when>
+                    <xsl:otherwise><xsl:value-of select="@name"/></xsl:otherwise>
+                </xsl:choose>
+            </xsl:variable>
+            <xsl:variable name="align" as="xs:integer">
+                <!-- padding added in structures to have fancy alignment -->
+                17
+                <!-- <xsl:choose>
+                    <xsl:when test="@name='DUMMY'">12</xsl:when> -->
+                    <!-- <xsl:when test="@name='ContentCompAlgo'">12</xsl:when> -->
+                    <!-- <xsl:when test="@name='TrackType'">9</xsl:when> -->
+                    <!-- <xsl:when test="@name='ProjectionType'">19</xsl:when> -->
+                    <!-- <xsl:when test="@name='FlagInterlaced'">13</xsl:when> -->
+                    <!-- <xsl:when test="@name='StereoMode'">19</xsl:when> -->
+                    <!-- <xsl:when test="@name='DisplayUnit'">12</xsl:when> -->
+                    <!-- <xsl:when test="@name='FieldOrder'">13</xsl:when> -->
+                    <!-- <xsl:otherwise>17</xsl:otherwise>
+                </xsl:choose> -->
+            </xsl:variable>
+
+            <xsl:text>/**&#10; *</xsl:text>
+            <xsl:value-of select="ebml:documentation[@purpose='definition']"/>
+            <xsl:text>&#10; */&#10;</xsl:text>
+            <xsl:text>typedef enum {&#10;</xsl:text>
+
+            <!-- Internal value not found in the specs -->
+            <!-- <xsl:if test="@name='TrackType'"><xsl:text>  MATROSKA_TRACK_TYPE_NONE     = 0x0,&#10;</xsl:text></xsl:if> -->
+            <xsl:if test="@name='ContentCompAlgo'">
+              <xsl:text>  MATROSKA_</xsl:text><xsl:value-of select="translate($prefix, 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"/><xsl:text>_NONE</xsl:text>
+              <xsl:value-of select="substring('            ',0,$align)"/>
+              <xsl:text> = -1,&#10;</xsl:text>
+            </xsl:if>
+
+            <xsl:for-each select="ebml:restriction/ebml:enum">
+                <xsl:sort select="value"/>
+                <xsl:text>  MATROSKA_</xsl:text>
+                <xsl:value-of select="translate($prefix, 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"/>
+                <xsl:text>_</xsl:text>
+                <xsl:call-template name="outputEnumLabel">
+                    <xsl:with-param name="label" select="@label"/>
+                    <xsl:with-param name="align" select="$align"/>
+                </xsl:call-template>
+
+                <xsl:text> = </xsl:text>
+                <xsl:choose>
+                    <xsl:when test="$prefix='TRACK_TYPE'">
+                        <xsl:call-template name="ConvertToHex">
+                            <xsl:with-param name="index" select="@value"/>
+                        </xsl:call-template>
+                    </xsl:when>
+                    <xsl:otherwise><xsl:value-of select="@value"/></xsl:otherwise>
+                </xsl:choose>
+                <xsl:choose>
+                    <xsl:when test="ebml:documentation[@purpose='definition']">
+                        <xsl:text>, // </xsl:text>
+                        <xsl:call-template name="cleanEnumDoc">
+                            <xsl:with-param name="label" select="ebml:documentation[@purpose='definition']"/>
+                        </xsl:call-template>
+                        <xsl:text>&#10;</xsl:text>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:text>,&#10;</xsl:text>
+                    </xsl:otherwise>
+                </xsl:choose>
+            </xsl:for-each>
+
+            <!-- Extra enum count -->
+            <!-- <xsl:choose> -->
+                <!-- <xsl:when test="@name='ContentCompAlgo'"><xsl:text>  MATROSKA_</xsl:text><xsl:value-of select="translate($prefix, 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"/><xsl:text>_NONE&#10;</xsl:text></xsl:when> -->
+                <!-- <xsl:when test="@name='ChromaSitingHorz'"><xsl:text>  MATROSKA_COLOUR_CHROMASITINGHORZ_NB&#10;</xsl:text></xsl:when> -->
+                <!-- <xsl:when test="@name='ChromaSitingVert'"><xsl:text>  MATROSKA_COLOUR_CHROMASITINGVERT_NB&#10;</xsl:text></xsl:when> -->
+                <!-- <xsl:when test="@name='StereoMode'"><xsl:text>  MATROSKA_VIDEO_STEREOMODE_TYPE_NB,&#10;</xsl:text></xsl:when> -->
+            <!-- </xsl:choose> -->
+
+            <xsl:text>} Matroska</xsl:text>
+            <xsl:choose>
+                <xsl:when test="@name='ContentCompAlgo'"><xsl:text>TrackEncodingCompAlgo</xsl:text></xsl:when>
+                <xsl:when test="@name='ChromaSitingHorz'"><xsl:text>ColourChromaSitingHorz</xsl:text></xsl:when>
+                <xsl:when test="@name='ChromaSitingVert'"><xsl:text>ColourChromaSitingVert</xsl:text></xsl:when>
+                <xsl:when test="@name='ChapProcessTime'"><xsl:text>ChapterProcessTime</xsl:text></xsl:when>
+                <xsl:when test="@name='ContentSigAlgo'"><xsl:text>ContentSignatureAlgo</xsl:text></xsl:when>
+                <xsl:when test="@name='ContentEncAlgo'"><xsl:text>ContentEncodingAlgo</xsl:text></xsl:when>
+                <!-- <xsl:when test="@name='FlagInterlaced'"><xsl:text>VideoInterlaceFlag</xsl:text></xsl:when> -->
+                <!-- <xsl:when test="@name='StereoMode'"><xsl:text>VideoStereoModeType</xsl:text></xsl:when> -->
+                <xsl:when test="contains(@path,'\TrackEntry\Video\')"><xsl:text>Video</xsl:text><xsl:value-of select="@name"/></xsl:when>
+                <xsl:when test="contains(@path,'\TrackEntry\Audio\')"><xsl:text>Audio</xsl:text><xsl:value-of select="@name"/></xsl:when>
+                <xsl:otherwise><xsl:value-of select="@name"/></xsl:otherwise>
+            </xsl:choose>
+            <xsl:text>;&#10;&#10;</xsl:text>
+        </xsl:if>
+    </xsl:template>
+
+  <xsl:template name="outputEnumLabel">
+    <xsl:param name="label"/>
+    <xsl:param name="align" as="xs:integer"/>
+    <!-- Turn the ebml_matroska.xml enum labels into the names used in libmatroska2 -->
+    <!-- Recursive calls until we end up with a matching name with no space, parenthesis, comas, etc -->
+    <xsl:choose>
+        <xsl:when test="$label='Header Stripping'">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'HeaderStrip'"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="$label='display aspect ratio'">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'DisplayAspectRatio'"/></xsl:call-template>
+        </xsl:when>
+        <!-- Field Order -->
+        <xsl:when test="$label='tff'">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'TopFieldFirst'"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="$label='bff'">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'BottomFieldFirst'"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="$label='tff(swapped)'">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'TopFieldSwapped'"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="$label='bff(swapped)'">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'BottomFieldSwapped'"/></xsl:call-template>
+        </xsl:when>
+
+        <!-- Stereo Mode -->
+        <xsl:when test="contains($label,'top - bottom (left eye is first)')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'top bottom'"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'top - bottom (right eye is first)')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'bottom top'"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'anaglyph (cyan/red)')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'anaglyph cyan red'"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'anaglyph (green/magenta)')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'anaglyph green mag'"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'side by side (')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="substring-after($label, 'side by side (')"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'(right eye is first)')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="concat(substring-before($label,'(right eye is first)'), 'rl')"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'(left eye is first)')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="concat(substring-before($label,'(left eye is first)'), 'lr')"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'left eye first')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'left right'"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'right eye first')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'right left'"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'column ')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="concat(concat(substring-before($label, 'column '), 'col '), substring-after($label, 'column '))"/></xsl:call-template>
+        </xsl:when>
+        <!-- <xsl:when test="contains($label,'checkboard ')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/>
+                <xsl:with-param name="label" select="concat(concat(substring-before($label, 'checkboard '), 'checkerboard '), substring-after($label, 'checkboard '))"/>
+            </xsl:call-template>
+        </xsl:when> -->
+        <xsl:when test="contains($label,'laced in one ')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="concat(substring-before($label, 'laced in one '), substring-after($label, 'laced in one '))"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'The ')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="concat(substring-before($label, 'The '), substring-after($label, 'The '))"/></xsl:call-template>
+        </xsl:when>
+
+        <!-- chapter process time -->
+        <xsl:when test="contains($label,'during the ')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'during'"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'before starting ')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'before'"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'after playback ')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'after'"/></xsl:call-template>
+        </xsl:when>
+
+        <xsl:when test="contains($label,'SMPTE ST ')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="concat('SMPTE ' ,concat(substring-before($label, 'SMPTE ST '), substring-after($label, 'SMPTE ST ')))"/></xsl:call-template>
+        </xsl:when>
+
+        <!-- Transfer -->
+        <xsl:when test="contains($label,'Gamma 2.2 curve')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'Gamma22'"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'Gamma 2.8 curve')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'Gamma28'"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'ITU-R BT.709')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'BT709'"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'ITU-R BT.2020 10 bit')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'BT2020 10-bit'"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'ITU-R BT.2020 12 bit')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'BT2020 12-bit'"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'ITU-R BT.2020')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'BT2020'"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'ITU-R BT.1361')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'BT1361 ECG'"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'Perceptual Quantization')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'BT2100 PQ'"/></xsl:call-template>
+        </xsl:when>
+
+        <!-- Primaries -->
+        <xsl:when test="contains($label,'EBU Tech. 3213-E')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'JEDEC_P22'"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'ITU-R BT.470BG')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'BT470BG'"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'ITU-R BT.470M')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'BT470M'"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'ITU-R BT.601 525')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="'BT601 525'"/></xsl:call-template>
+        </xsl:when>
+        
+        <!-- MatrixCoefficients -->
+        <xsl:when test="contains($label,' Non-constant Luminance')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="concat(concat(substring-before($label, ' Non-constant Luminance'), substring-after($label, ' Non-constant Luminance')),' NCL')"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,' Constant Luminance')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="concat(concat(substring-before($label, ' Constant Luminance'), substring-after($label, ' Constant Luminance')),' CL')"/></xsl:call-template>
+        </xsl:when>
+
+        <xsl:when test="contains($label,')')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="substring-before($label, ')')"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,' collocated')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="substring-before($label, ' collocated')"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,' (')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="substring-before($label, ' (')"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,' /')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="substring-before($label, ' /')"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'__')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="concat(substring-before($label, '__'), substring-after($label, '__'))"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'-')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="translate($label, '-', '_')"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,' ')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="translate($label, ' ', '_')"/></xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'.')">
+            <xsl:call-template name="outputEnumLabel"><xsl:with-param name="align" select="$align"/><xsl:with-param name="label" select="translate($label, '.', '_')"/></xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise>
+            <!-- Now we have a suitable name, output it in upper case with padding -->
+            <xsl:call-template name="finalOutputEnumLabel">
+                <xsl:with-param name="label" select="translate($label, 'abcdefghijklmnopqrstuvwxyz', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"/>
+                <xsl:with-param name="align" select="$align"/>
+            </xsl:call-template>
+        </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  
+  <xsl:template name="finalOutputEnumLabel">
+    <xsl:param name="label"/>
+    <xsl:param name="align" as="xs:integer"/>
+    <xsl:choose>
+        <xsl:when test="string-length($label) &lt; $align">
+            <xsl:value-of select="substring(concat($label, '                          '),0,$align)"/>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:value-of select="$label"/>
+        </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="cleanEnumDoc">
+    <xsl:param name="label"/>
+    <xsl:choose>
+        <xsl:when test="contains($label,' [@!')">
+            <xsl:call-template name="cleanEnumDoc">
+                <xsl:with-param name="label" select="concat(substring-before($label, ' [@!'), ' (', substring-before(substring-after($label, ' [@!'), ']'), ')', substring-after(substring-after($label, ' [@!'), ']'))"/>
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,' [@?')">
+            <xsl:call-template name="cleanEnumDoc">
+                <xsl:with-param name="label" select="concat(substring-before($label, ' [@?'), ' (', substring-before(substring-after($label, ' [@?'), ']'), ')', substring-after(substring-after($label, ' [@?'), ']'))"/>
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,'; see usage notes')">
+            <xsl:call-template name="cleanEnumDoc">
+                <xsl:with-param name="label" select="concat(substring-before($label, '; see usage notes'), substring-after($label, '; see usage notes'))"/>
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:value-of select="translate($label, '&#10;', ' ')"/>
+        </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <!-- HTML tags found in documentation -->
+  <xsl:template match="a">
+    <a href="{@href}"><xsl:apply-templates/></a>
+  </xsl:template>
+  <xsl:template match="strong">
+    <strong><xsl:apply-templates/></strong>
+  </xsl:template>
+  <xsl:template match="br">
+    <br/><xsl:apply-templates/>
+  </xsl:template>
+
+  <xsl:template match="comment()">
+    <xsl:comment>
+      <xsl:value-of select="."/>
+    </xsl:comment>
+  </xsl:template>
+
+  <xsl:template match="@* | node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@* | node()"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
As 2.0 evolves we can't keep the same generated code on both sides. Especially as the class names will change for https://github.com/Matroska-Org/libmatroska/issues/137