### PR TITLE
spectools: Use a macro to set the length constraint on binary elements

### DIFF
--- a/spectool/schema_2_kaxsemantic_h.xsl
+++ b/spectool/schema_2_kaxsemantic_h.xsl
@@ -105,7 +105,7 @@ namespace libmatroska {
             <xsl:text>  libebml::filepos_t RenderData(libebml::IOCallback &amp; output, bool bForceRender, ShouldWrite writeFilter) override;&#10;</xsl:text>
         </xsl:if>
         <xsl:if test="@length">
-            <xsl:text>  bool ValidateSize() const override {return IsFiniteSize() &amp;&amp; GetSize() </xsl:text>
+            <xsl:text>  bool ValidateSize() const override {return GetSize() </xsl:text>
             <xsl:choose>
                 <xsl:when test="contains(@length, '=') or contains(@length, '&lt;') or contains(@length, '&gt;')"><xsl:value-of select="@length"/></xsl:when>
                 <xsl:otherwise><xsl:text>== </xsl:text><xsl:value-of select="@length"/></xsl:otherwise>

--- a/spectool/schema_2_kaxsemantic_h.xsl
+++ b/spectool/schema_2_kaxsemantic_h.xsl
@@ -67,6 +67,7 @@ namespace libmatroska {
             </xsl:when>
             <xsl:when test="@type='binary'">
                 <xsl:text>DECLARE_MKX_BINARY</xsl:text>
+                <xsl:if test="@length"><xsl:text>_LENGTH</xsl:text></xsl:if>
             </xsl:when>
             <xsl:when test="@type='uinteger'">
                 <xsl:text>DECLARE_MKX_UINTEGER</xsl:text>
@@ -97,20 +98,15 @@ namespace libmatroska {
         <xsl:call-template name="get-class-name">
             <xsl:with-param name="node" select="."/>
         </xsl:call-template>
+        <xsl:if test="@length">
+            <xsl:text>, </xsl:text><xsl:value-of select="@length"/>
+        </xsl:if>
         <xsl:text>)&#10;</xsl:text>
-        <xsl:if test="@maxver='0' or @maxver='1' or @maxver='2' or @maxver='3' or @length">
+        <xsl:if test="@maxver='0' or @maxver='1' or @maxver='2' or @maxver='3'">
             <xsl:text>public:&#10;</xsl:text>
         </xsl:if>
         <xsl:if test="@maxver='0' or @maxver='1' or @maxver='2' or @maxver='3'">
             <xsl:text>  libebml::filepos_t RenderData(libebml::IOCallback &amp; output, bool bForceRender, ShouldWrite writeFilter) override;&#10;</xsl:text>
-        </xsl:if>
-        <xsl:if test="@length">
-            <xsl:text>  bool ValidateSize() const override {return GetSize() </xsl:text>
-            <xsl:choose>
-                <xsl:when test="contains(@length, '=') or contains(@length, '&lt;') or contains(@length, '&gt;')"><xsl:value-of select="@length"/></xsl:when>
-                <xsl:otherwise><xsl:text>== </xsl:text><xsl:value-of select="@length"/></xsl:otherwise>
-            </xsl:choose>
-            <xsl:text>;}&#10;</xsl:text>
         </xsl:if>
         <xsl:text>};&#10;</xsl:text>
         <!-- <xsl:if test="$minVer &gt; 1 or ebml:extension[@divx='1']">#endif&#10;</xsl:if> -->


### PR DESCRIPTION
String may have size constraints in EBML but we don't use that.