### PR TITLE
Build helper libraries with position-independent code if BUILD_SHARED_LIBS is set.

### DIFF
--- a/corec/corec/helpers/zlib/CMakeLists.txt
+++ b/corec/corec/helpers/zlib/CMakeLists.txt
@@ -4,6 +4,9 @@ option(CONFIG_ZLIB "Enable zlib (de)compression" ON)
 
 if (CONFIG_ZLIB)
     add_library("zlib" STATIC)
+    if (BUILD_SHARED_LIBS)
+        set_property(TARGET "zlib" PROPERTY POSITION_INDEPENDENT_CODE ON)
+    endif()
     set(zlib_group_PUBLIC_HEADERS
         crc32.h
         inffast.h

--- a/libmatroska2/bzip2/CMakeLists.txt
+++ b/libmatroska2/bzip2/CMakeLists.txt
@@ -1,6 +1,9 @@
 # bzlib library API
 
 add_library("bzlib" STATIC)
+if (BUILD_SHARED_LIBS)
+    set_property(TARGET "bzlib" PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
 set(BZLIB_GROUP_PUBLIC_HEADERS
     bzlib.h
 )

--- a/libmatroska2/minilzo/CMakeLists.txt
+++ b/libmatroska2/minilzo/CMakeLists.txt
@@ -1,6 +1,9 @@
 # minilzo library API
 
 add_library("minilzo" STATIC)
+if (BUILD_SHARED_LIBS)
+    set_property(TARGET "minilzo" PROPERTY POSITION_INDEPENDENT_CODE ON)
+endif()
 set(MINILZO_GROUP_PUBLIC_HEADERS
     minilzo.h
     lzoconf.h


### PR DESCRIPTION
If this is not done, `cmake .. -DBUILD_SHARED_LIBS=ON && cmake --build .` will fail like so:

```
/usr/bin/ld: ../corec/corec/helpers/zlib/libzlib.a(deflate.c.o): warning: relocation against `z_errmsg' in read-only section `.text'
/usr/bin/ld: ../corec/corec/helpers/zlib/libzlib.a(zutil.c.o): relocation R_X86_64_PC32 against symbol `z_errmsg' can not be used when making a shared object; recompile with -fPIC
/usr/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status
gmake[2]: *** [libmatroska2/CMakeFiles/matroska2.dir/build.make:132: libmatroska2/libmatroska2.so] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:492: libmatroska2/CMakeFiles/matroska2.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
```

(And so on for each static helper library.)