### PR TITLE
CI: avoid build spectools/tools when not necessary

### DIFF
--- a/.github/workflows/generate-tools.yaml
+++ b/.github/workflows/generate-tools.yaml
@@ -1,5 +1,8 @@
 name: "Build tools"
-on: pull_request
+on:
+  paths-ignore:
+    paths:
+      - 'spectool/**'
 
 jobs:
   build_tools_win32:

--- a/.github/workflows/libmatroska-semantic.yaml
+++ b/.github/workflows/libmatroska-semantic.yaml
@@ -2,6 +2,8 @@ name: "libmatroska Semantic"
 on:
   push:
     branches: [ master ]
+    paths:
+      - 'spectool/**'
   pull_request:
     # branches: [ master ]
   schedule:

--- a/.github/workflows/libmatroska-semantic_1x.yaml
+++ b/.github/workflows/libmatroska-semantic_1x.yaml
@@ -2,6 +2,8 @@ name: "libmatroska v1.x Semantic"
 on:
   push:
     branches: [ master ]
+    paths:
+      - 'spectool/**'
   pull_request:
     # branches: [ master ]
   schedule:

--- a/.github/workflows/libmatroska2-semantic.yaml
+++ b/.github/workflows/libmatroska2-semantic.yaml
@@ -2,6 +2,8 @@ name: "libmatroska2 Semantic"
 on:
   push:
     branches: [ master ]
+    paths:
+      - 'spectool/**'
   pull_request:
     # branches: [ master ]
   schedule:


### PR DESCRIPTION
So we don't get failed build on semantic of libmatroska when we're not changing anything about that.
That will build less/faster as well.