### PR TITLE
libmatroska2: change decompression options

### DIFF
--- a/libmatroska2/CMakeLists.txt
+++ b/libmatroska2/CMakeLists.txt
@@ -1,8 +1,8 @@
 project("matroska2" VERSION 0.22.3 LANGUAGES C)
 
 option(CONFIG_ZLIB "Enable zlib (de)compression" ON)
-option(CONFIG_BZLIB "Enable bzlib (de)compression in libmatroska2" ON)
-option(CONFIG_LZO1X "Enable lzo (de)compression in libmatroska2" ON)
+option(CONFIG_BZLIB "Enable bzlib decompression in libmatroska2" ON)
+option(CONFIG_LZO1X "Enable lzo decompression in libmatroska2" ON)
 option(CONFIG_NOCODEC_HELPER "Enable Vorbis frame durations in libmatroska2" ON)
 
 if (CONFIG_ZLIB)


### PR DESCRIPTION
As said in RFC9559, we should not compress to bzlib and lzo anymore. The code already only supports decompression.
Let's reflect this in the option text.