### PR TITLE
only build corec files once

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,16 @@ if(DEV_MODE)
                           -Werror=missing-field-initializers
                           -Werror=excess-initializers
                           -Werror=strict-aliasing
+                          -Werror=array-bounds
+                          -Werror=format
+                          -Werror=incompatible-pointer-types
+                          -Werror=restrict
+                          -Werror=int-conversion
+                          -Werror=implicit-int
+                          -Werror=return-mismatch
+                          -Werror=declaration-missing-parameter-type
+                          -Werror=switch
+                          -Werror=return-type
                           -W4)
 endif()
 

--- a/corec/corec/CMakeLists.txt
+++ b/corec/corec/CMakeLists.txt
@@ -115,7 +115,7 @@ else(BUILD_SHARED_LIBS)
 endif(BUILD_SHARED_LIBS)
 
 set(corec_PUBLIC_HEADERS
-  ${corec_node_PUBLIC_HEADERS} ${corec_parser_PUBLIC_HEADERS} ${core_md5_PUBLIC_HEADERS}
+  ${corec_node_PUBLIC_HEADERS} ${corec_parser_PUBLIC_HEADERS}
 )
 
 set_target_properties("corec" PROPERTIES

--- a/corec/corec/CMakeLists.txt
+++ b/corec/corec/CMakeLists.txt
@@ -45,10 +45,9 @@ set(corec_node_PUBLIC_HEADERS
   ${CMAKE_CURRENT_SOURCE_DIR}/node/nodetree.h
   ${CMAKE_CURRENT_SOURCE_DIR}/node/nodetools.h
 )
-add_library("corec_node" INTERFACE)
-target_sources("corec_node" INTERFACE ${corec_node_SOURCES} ${corec_node_PUBLIC_HEADERS})
-target_include_directories("corec_node" INTERFACE ".")
-target_link_libraries("corec_node" INTERFACE "corec_array" "corec_str" "corec_file")
+add_library("corec_node" ${corec_node_SOURCES} ${corec_node_PUBLIC_HEADERS} ${corec_base_PUBLIC_HEADERS})
+target_include_directories("corec_node" PUBLIC ".")
+target_link_libraries("corec_node" PRIVATE "corec_bare")
 
 # Array API
 set(corec_array_SOURCES
@@ -57,12 +56,10 @@ set(corec_array_SOURCES
 set(corec_array_PUBLIC_HEADERS
   ${CMAKE_CURRENT_SOURCE_DIR}/array/array.h
 )
-add_library("corec_array" INTERFACE)
-target_sources("corec_array" INTERFACE ${corec_array_SOURCES} ${corec_array_PUBLIC_HEADERS})
-target_link_libraries("corec_array" INTERFACE "corec_bare")
+add_library("corec_array" ${corec_array_SOURCES} ${corec_array_PUBLIC_HEADERS} ${corec_base_PUBLIC_HEADERS})
+target_link_libraries("corec_array" PRIVATE "corec_bare")
 
 # String API
-add_library("corec_str" INTERFACE)
 set(corec_str_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/str/str.c
 )
@@ -78,44 +75,52 @@ set(corec_str_LINUX_SOURCES
 set(corec_str_PUBLIC_HEADERS
   ${CMAKE_CURRENT_SOURCE_DIR}/str/str.h
 )
-target_sources("corec_str" INTERFACE  ${corec_str_SOURCES} ${corec_str_PUBLIC_HEADERS})
+add_library("corec_str" ${corec_str_SOURCES} ${corec_str_PUBLIC_HEADERS})
 if (WIN32)
-  target_sources("corec_str" INTERFACE ${corec_str_WIN32_SOURCES})
+  target_sources("corec_str" PRIVATE ${corec_str_WIN32_SOURCES})
 elseif(APPLE)
-    target_sources("corec_str" INTERFACE ${corec_str_OSX_SOURCES})
+    target_sources("corec_str" PRIVATE ${corec_str_OSX_SOURCES})
 elseif(UNIX)
-    target_sources("corec_str" INTERFACE ${corec_str_LINUX_SOURCES})
+    target_sources("corec_str" PRIVATE ${corec_str_LINUX_SOURCES})
 endif(WIN32)
+target_include_directories("corec_str" PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>)
+target_include_directories("corec_str" PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
 add_subdirectory("helpers")
 
-add_library("corec")
+add_library("corec" INTERFACE ${corec_base_PUBLIC_HEADERS})
+set_target_properties("corec" PROPERTIES LINKER_LANGUAGE C)
 target_include_directories("corec"
-  PRIVATE
+  INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
-  PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/helpers>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 # keep until the sources are split
-target_include_directories("corec" PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+target_include_directories("corec" INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
 
 set(corec_INTERNAL_LIBS
-  $<BUILD_INTERFACE:corec_node>
   $<BUILD_INTERFACE:corec_parser>
+  $<BUILD_INTERFACE:corec_node>
+  $<BUILD_INTERFACE:corec_array>
+  $<BUILD_INTERFACE:corec_str>
+  $<BUILD_INTERFACE:corec_charconvert>
+  $<BUILD_INTERFACE:corec_file>
+  $<BUILD_INTERFACE:corec_date>
 )
 
 if (BUILD_SHARED_LIBS)
-  target_link_libraries("corec" PRIVATE ${corec_INTERNAL_LIBS})
-  target_compile_definitions("corec" PUBLIC NODE_IMPORTS ARRAY_IMPORTS CHARCONVERT_IMPORTS DATE_IMPORTS FILE_IMPORTS STR_IMPORTS)
+  target_link_libraries("corec" INTERFACE ${corec_INTERNAL_LIBS})
+  target_compile_definitions("corec" INTERFACE NODE_IMPORTS ARRAY_IMPORTS CHARCONVERT_IMPORTS DATE_IMPORTS FILE_IMPORTS STR_IMPORTS)
 else(BUILD_SHARED_LIBS)
-  target_link_libraries("corec" PUBLIC ${corec_INTERNAL_LIBS})
+  target_link_libraries("corec" INTERFACE ${corec_INTERNAL_LIBS})
 endif(BUILD_SHARED_LIBS)
 
 set(corec_PUBLIC_HEADERS
-  ${corec_node_PUBLIC_HEADERS} ${corec_parser_PUBLIC_HEADERS}
+  ${corec_node_PUBLIC_HEADERS}
+  ${corec_parser_PUBLIC_HEADERS}
 )
 
 set_target_properties("corec" PROPERTIES

--- a/corec/corec/helpers/CMakeLists.txt
+++ b/corec/corec/helpers/CMakeLists.txt
@@ -19,32 +19,32 @@ set(corec_file_PUBLIC_HEADERS
   ${CMAKE_CURRENT_SOURCE_DIR}/file/streams.h
   PARENT_SCOPE
 )
-add_library("corec_file" INTERFACE)
-target_sources("corec_file" INTERFACE ${corec_file_BASE_SOURCES} ${corec_file_PUBLIC_HEADERS})
+add_library("corec_file" ${corec_file_BASE_SOURCES} ${corec_file_PUBLIC_HEADERS})
 if (CONFIG_STDIO)
-  target_sources("corec_file" INTERFACE ${corec_file_STDIO_SOURCES})
+  target_sources("corec_file" PRIVATE ${corec_file_STDIO_SOURCES})
 endif(CONFIG_STDIO)
 if (WIN32)
-  target_sources("corec_file" INTERFACE ${corec_file_WIN32_SOURCES})
+  target_sources("corec_file" PRIVATE ${corec_file_WIN32_SOURCES})
 
   # for SHFileOperation to move files in the recycle bin
-  target_link_libraries("corec_file" INTERFACE shell32)
+  target_link_libraries("corec_file" PRIVATE shell32)
 elseif(UNIX)
   check_include_file(sys/mount.h   HAVE_SYS_MOUNT_H)
   check_include_file(sys/vfs.h     HAVE_SYS_VFS_H)
   check_include_file(sys/statvfs.h HAVE_SYS_STATVFS_H)
   if (HAVE_SYS_MOUNT_H)
-    target_compile_definitions("corec_file" INTERFACE HAVE_SYS_MOUNT_H)
+    target_compile_definitions("corec_file" PRIVATE HAVE_SYS_MOUNT_H)
   endif()
   if (HAVE_SYS_VFS_H)
-    target_compile_definitions("corec_file" INTERFACE HAVE_SYS_VFS_H)
+    target_compile_definitions("corec_file" PRIVATE HAVE_SYS_VFS_H)
   endif()
   if (HAVE_SYS_STATVFS_H)
-    target_compile_definitions("corec_file" INTERFACE HAVE_SYS_STATVFS_H)
+    target_compile_definitions("corec_file" PRIVATE HAVE_SYS_STATVFS_H)
   endif()
-  target_sources("corec_file" INTERFACE ${corec_file_UNIX_SOURCES})
+  target_sources("corec_file" PRIVATE ${corec_file_UNIX_SOURCES})
 endif(WIN32)
-target_link_libraries("corec_file" INTERFACE "corec_node" "corec_date")
+target_include_directories("corec_file" PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>)
+target_include_directories("corec_file" PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/..>)
 
 # Parser API
 set(corec_parser_SOURCES
@@ -68,17 +68,16 @@ set(corec_parser_PUBLIC_HEADERS
   ${CMAKE_CURRENT_SOURCE_DIR}/parser/urlpart.h
   PARENT_SCOPE
 )
-add_library("corec_parser" INTERFACE)
-target_sources("corec_parser" INTERFACE ${corec_parser_SOURCES} ${corec_parser_PUBLIC_HEADERS})
-target_link_libraries("corec_parser" INTERFACE "corec_str" "corec_charconvert" "corec_file")
+add_library("corec_parser" ${corec_parser_SOURCES} ${corec_parser_PUBLIC_HEADERS})
+target_include_directories("corec_parser" PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>)
+target_include_directories("corec_parser" PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/..>)
 if (CYGWIN)
 # if CMake wasn't this piece of shit this would simply work
-  target_link_libraries("corec_parser" INTERFACE iconv)
+  target_link_libraries("corec_parser" PRIVATE iconv)
 endif (CYGWIN)
-target_include_directories("corec_parser" INTERFACE ".")
+target_include_directories("corec_parser" PUBLIC ".")
 
 # Date API
-add_library("corec_date" INTERFACE)
 set(corec_date_WIN32_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/date/date_win32.c
 )
@@ -89,13 +88,14 @@ set(corec_date_PUBLIC_HEADERS
   ${CMAKE_CURRENT_SOURCE_DIR}/date/date.h
   PARENT_SCOPE
 )
+add_library("corec_date" ${corec_date_PUBLIC_HEADERS} ${corec_base_PUBLIC_HEADERS})
 if (WIN32)
-  target_sources("corec_date" INTERFACE ${corec_date_WIN32_SOURCES})
+  target_sources("corec_date" PRIVATE ${corec_date_WIN32_SOURCES})
 elseif(UNIX)
-    target_sources("corec_date" INTERFACE ${corec_date_UNIX_SOURCES})
+    target_sources("corec_date" PRIVATE ${corec_date_UNIX_SOURCES})
 endif(WIN32)
-target_sources("corec_date" INTERFACE ${corec_date_PUBLIC_HEADERS})
-target_link_libraries("corec_date" INTERFACE "corec_bare")
+target_include_directories("corec_date" PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>)
+target_include_directories("corec_date" PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/..>)
 
 # Character Conversion API
 set(corec_charconvert_WIN32_SOURCES
@@ -114,18 +114,19 @@ set(corec_charconvert_PUBLIC_HEADERS
   ${CMAKE_CURRENT_SOURCE_DIR}/charconvert/charconvert.h
   PARENT_SCOPE
 )
-add_library("corec_charconvert" INTERFACE)
+add_library("corec_charconvert" ${corec_charconvert_PUBLIC_HEADERS} ${corec_base_PUBLIC_HEADERS})
 if (WIN32)
-  target_sources("corec_charconvert" INTERFACE ${corec_charconvert_WIN32_SOURCES})
+  target_sources("corec_charconvert" PRIVATE ${corec_charconvert_WIN32_SOURCES})
 elseif(APPLE)
-  target_link_libraries("corec_charconvert" INTERFACE "-framework CoreFoundation")
-  target_sources("corec_charconvert" INTERFACE ${corec_charconvert_OSX_SOURCES})
+  target_link_libraries("corec_charconvert" PRIVATE "-framework CoreFoundation")
+  target_sources("corec_charconvert" PRIVATE ${corec_charconvert_OSX_SOURCES})
 elseif(UNIX)
-  target_sources("corec_charconvert" INTERFACE ${corec_charconvert_LINUX_SOURCES})
+  target_sources("corec_charconvert" PRIVATE ${corec_charconvert_LINUX_SOURCES})
 else(UNIX)
-  target_sources("corec_charconvert" INTERFACE ${corec_charconvert_OTHER_SOURCES})
+  target_sources("corec_charconvert" PRIVATE ${corec_charconvert_OTHER_SOURCES})
   if (CYGWIN)
-    target_link_libraries("corec_charconvert" INTERFACE iconv)
+    target_link_libraries("corec_charconvert" PRIVATE iconv)
   endif (CYGWIN)
 endif(WIN32)
-target_link_libraries("corec_charconvert" INTERFACE "corec_bare")
+target_include_directories("corec_charconvert" PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>)
+target_include_directories("corec_charconvert" PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/..>)

--- a/corec/corec/helpers/file/streams.h
+++ b/corec/corec/helpers/file/streams.h
@@ -119,9 +119,11 @@ typedef struct memstream
 
 } memstream;
 
+#if defined(CONFIG_STDIO)
 #define STDIN_ID		FOURCC('S','T','D','I')
 #define STDOUT_ID		FOURCC('S','T','D','O')
 #define STDERR_ID		FOURCC('S','T','D','E')
+#endif
 
 typedef struct streamdir
 {

--- a/corec/corec/node/node.c
+++ b/corec/corec/node/node.c
@@ -328,7 +328,7 @@ typedef struct class_ref_t
 
 } class_ref_t;
 
-static int CmpClassRef(void* UNUSED_PARAM(p), const void* va, const void* vb)
+static int CmpClassRef(const void* UNUSED_PARAM(p), const void* va, const void* vb)
 {
     const class_ref_t *a = va;
     const class_ref_t *b = vb;

--- a/corec/corec/node/nodetools.h
+++ b/corec/corec/node/nodetools.h
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * 
+ *
  * Copyright (c) 2008-2010, CoreCodec, Inc.
  * All rights reserved.
  *
@@ -32,114 +32,13 @@
 
 //some helper functions
 
-static INLINE tchar_t* tcsdup(const tchar_t* s)
-{
-	size_t n = tcslen(s)+1;
-	tchar_t* p = (tchar_t*)malloc(n*sizeof(tchar_t));
-	if (p) tcscpy_s(p,n,s);
-	return p;
-}
-
-static INLINE bool_t EqInt(const int* a, const int* b) { return *a == *b; }
-static INLINE bool_t EqTick(const tick_t* a, const tick_t* b) { return *a == *b; }
-static INLINE bool_t EqBool(const bool_t* a, const bool_t* b) { return *a == *b; }
-static INLINE bool_t EqPtr(void** a, void** b) { return *a == *b; }
 static INLINE bool_t EqFrac(const cc_fraction* a, const cc_fraction* b)
 {
-	if (a->Den == b->Den && a->Num == b->Num) 
+	if (a->Den == b->Den && a->Num == b->Num)
 		return 1;
 	if (!a->Den) return b->Den==0;
 	if (!b->Den) return 0;
 	return (int64_t)b->Den * a->Num == (int64_t)a->Den * b->Num;
-}
-
-// variable names: Result, Data, Size
-
-#define GETVALUE(Value,Type)								\
-		{													\
-			assert(Size == sizeof(Type));					\
-			*(Type*)Data = Value;							\
-			Result = ERR_NONE;								\
-		}
-
-#define GETVALUECOND(Value,Type,Cond)						\
-		{													\
-			assert(Size == sizeof(Type));					\
-			if (Cond)										\
-			{												\
-				*(Type*)Data = Value;						\
-				Result = ERR_NONE;							\
-			}												\
-		}
-    
-#define SETVALUE(Value,Type,Update)							\
-		{													\
-			assert(Size == sizeof(Type));					\
-			Value = *(Type*)Data;							\
-			Result = Update;								\
-		}
-
-#define SETVALUENULL(Value,Type,Update,Null)				\
-		{													\
-			if (Data)										\
-			{												\
-				assert(Size == sizeof(Type));				\
-				Value = *(Type*)Data;						\
-			}												\
-			else											\
-				Null;										\
-			Result = Update;								\
-		}
-
-#define SETVALUECOND(Value,Type,Update,Cond)				\
-		{													\
-			assert(Size == sizeof(Type));					\
-			if (Cond)										\
-			{												\
-				Value = *(Type*)Data;						\
-				Result = Update;							\
-			}												\
-		}
-
-#define SETVALUECMP(Value,Type,Update,EqFunc)				\
-		{													\
-			assert(Size == sizeof(Type));					\
-			Result = ERR_NONE;								\
-			if (!EqFunc(&Value,(Type*)Data))				\
-			{												\
-				Value = *(Type*)Data;						\
-				Result = Update;							\
-			}												\
-		}
-
-#define SETPACKETFORMAT(Value,Type,Update)					\
-		{													\
-			assert(Size == sizeof(Type) || !Data);			\
-			Result = PacketFormatCopy(&Value,(Type*)Data);	\
-			if (Result == ERR_NONE)							\
-				Result = Update;							\
-		}
-
-#define SETPACKETFORMATCMP(Value,Type,Update)				\
-		{													\
-			assert(Size == sizeof(Type) || !Data);			\
-			Result = ERR_NONE;								\
-			if (!EqPacketFormat(&Value,(Type*)Data))		\
-			{												\
-				Result = PacketFormatCopy(&Value,(Type*)Data);\
-				if (Result == ERR_NONE)						\
-					Result = Update;						\
-			}												\
-		}
-
-static INLINE tick_t ScaleTick(int64_t v, int64_t Num, int64_t Den)
-{
-    return (tick_t)Scale64(v,Num,Den);
-}
-
-static INLINE filepos_t ScalePos(int64_t v, int64_t Num, int64_t Den)
-{
-    return (filepos_t)Scale64(v,Num,Den);
 }
 
 NODE_DLL int ScaleRound(int_fast32_t v,int_fast32_t Num,int_fast32_t Den);

--- a/corec/tests/CMakeLists.txt
+++ b/corec/tests/CMakeLists.txt
@@ -1,15 +1,15 @@
 add_executable("string_test" string_test.c)
-target_link_libraries("string_test" PUBLIC "corec_str" "corec_charconvert")
+target_link_libraries("string_test" PUBLIC "corec")
 if (CYGWIN)
 # if CMake wasn't this piece of shit this would simply work
   target_link_libraries("string_test" PRIVATE iconv)
 endif (CYGWIN)
 
 add_executable("file_test" file_test.c)
-target_link_libraries("file_test" PUBLIC "corec_file")
+target_link_libraries("file_test" PUBLIC "corec")
 
 add_executable("node_test" node_test.c)
-target_link_libraries("node_test" PUBLIC "corec_node")
+target_link_libraries("node_test" PUBLIC "corec")
 
 # add_executable("parser_test" parser_test.c)
 # target_link_libraries("parser_test" PUBLIC "corec_parser")

--- a/corec/tests/file_test.c
+++ b/corec/tests/file_test.c
@@ -1,5 +1,19 @@
 #include "corec/helpers/file/file.h"
 
+#include <stdio.h>
+void DebugMessage(const tchar_t* Msg,...)
+{
+    va_list Args;
+    tchar_t Buffer[1024];
+
+    va_start(Args,Msg);
+    vstprintf_s(Buffer,TSIZEOF(Buffer), Msg, Args);
+    va_end(Args);
+    tcscat_s(Buffer,TSIZEOF(Buffer),T("\r\n"));
+
+    fprintf(stderr, "%s", Buffer);
+}
+
 int main(int argc,char** argv)
 {
     nodecontext Context;

--- a/corec/tests/node_test.c
+++ b/corec/tests/node_test.c
@@ -1,5 +1,19 @@
 #include "corec/node/node.h"
 
+#include <stdio.h>
+void DebugMessage(const tchar_t* Msg,...)
+{
+    va_list Args;
+    tchar_t Buffer[1024];
+
+    va_start(Args,Msg);
+    vstprintf_s(Buffer,TSIZEOF(Buffer), Msg, Args);
+    va_end(Args);
+    tcscat_s(Buffer,TSIZEOF(Buffer),T("\r\n"));
+
+    fprintf(stderr, "%s", Buffer);
+}
+
 int main(int argc,char** argv)
 {
     node* p[10000];

--- a/libebml2/CMakeLists.txt
+++ b/libebml2/CMakeLists.txt
@@ -68,7 +68,7 @@ install(EXPORT Ebml2 DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/ebml2)
 
 # TODO fix build
 add_executable("ebmltree" test/ebmltree.c)
-target_link_libraries("ebmltree" PUBLIC "ebml2")
+target_link_libraries("ebmltree" PUBLIC "ebml2" "corec")
 
 # TODO finish this
 # configure_file(legacy/ebml2_legacy_project.h.in legacy/ebml2_legacy_project.h)

--- a/libebml2/test/ebmltree.c
+++ b/libebml2/test/ebmltree.c
@@ -30,6 +30,19 @@
 
 #include "ebml2/ebml.h"
 
+void DebugMessage(const tchar_t* Msg,...)
+{
+    va_list Args;
+    tchar_t Buffer[1024];
+
+    va_start(Args,Msg);
+    vstprintf_s(Buffer,TSIZEOF(Buffer), Msg, Args);
+    va_end(Args);
+    tcscat_s(Buffer,TSIZEOF(Buffer),T("\r\n"));
+
+    fprintf(stderr, "%s", Buffer);
+}
+
 static ebml_element *OutputElement(ebml_element *Element, const ebml_parser_context *Context, stream *Input, int *Level)
 {
     int LevelPrint;

--- a/libmatroska2/test/mkvtree.c
+++ b/libmatroska2/test/mkvtree.c
@@ -74,6 +74,20 @@ void DebugMessage(const tchar_t* Msg,...)
 }
 #endif
 }
+#else
+#include <stdio.h>
+void DebugMessage(const tchar_t* Msg,...)
+{
+    va_list Args;
+    tchar_t Buffer[1024];
+
+    va_start(Args,Msg);
+    vstprintf_s(Buffer,TSIZEOF(Buffer), Msg, Args);
+    va_end(Args);
+    tcscat_s(Buffer,TSIZEOF(Buffer),T("\r\n"));
+
+    fprintf(stderr, "%s", Buffer);
+}
 #endif
 
 static void EndLine(ebml_element *Element)

--- a/mkclean/mkclean.c
+++ b/mkclean/mkclean.c
@@ -100,6 +100,20 @@ void DebugMessage(const tchar_t* Msg,...)
 }
 #endif
 }
+#else
+#include <stdio.h>
+void DebugMessage(const tchar_t* Msg,...)
+{
+    va_list Args;
+    tchar_t Buffer[1024];
+
+    va_start(Args,Msg);
+    vstprintf_s(Buffer,TSIZEOF(Buffer), Msg, Args);
+    va_end(Args);
+    tcscat_s(Buffer,TSIZEOF(Buffer),T("\r\n"));
+
+    fprintf(stderr, "%s", Buffer);
+}
 #endif
 
 #define EXTRA_SEEK_SPACE       22

--- a/mkparts/mkparts.c
+++ b/mkparts/mkparts.c
@@ -91,6 +91,20 @@ void DebugMessage(const tchar_t* Msg,...)
 }
 #endif
 }
+#else
+#include <stdio.h>
+void DebugMessage(const tchar_t* Msg,...)
+{
+    va_list Args;
+    tchar_t Buffer[1024];
+
+    va_start(Args,Msg);
+    vstprintf_s(Buffer,TSIZEOF(Buffer), Msg, Args);
+    va_end(Args);
+    tcscat_s(Buffer,TSIZEOF(Buffer),T("\r\n"));
+
+    fprintf(stderr, "%s", Buffer);
+}
 #endif
 
 static int OutputError(int ErrCode, const tchar_t *ErrString, ...)

--- a/mkvalidator/mkvalidator.c
+++ b/mkvalidator/mkvalidator.c
@@ -109,6 +109,20 @@ void DebugMessage(const tchar_t* Msg,...)
 }
 #endif
 }
+#else
+#include <stdio.h>
+void DebugMessage(const tchar_t* Msg,...)
+{
+    va_list Args;
+    tchar_t Buffer[1024];
+
+    va_start(Args,Msg);
+    vstprintf_s(Buffer,TSIZEOF(Buffer), Msg, Args);
+    va_end(Args);
+    tcscat_s(Buffer,TSIZEOF(Buffer),T("\r\n"));
+
+    fprintf(stderr, "%s", Buffer);
+}
 #endif
 
 static const tchar_t *GetProfileName(size_t ProfileNum)


### PR DESCRIPTION
The corec library doesn't have different compilation options depending on the mk<tool> compiled. We can use a single (static) library for corec.

Plus more compilation error checks and code cleaning.