### PR TITLE
mkclean: avoid using uninitialized variables

### DIFF
--- a/corec/corec/portab.h
+++ b/corec/corec/portab.h
@@ -473,9 +473,11 @@ void * __alloca(size_t size);
 #ifdef CONFIG_FILEPOS_64
 typedef int_fast64_t filepos_t;
 #define MAX_FILEPOS INT_FAST64_MAX
+#define MIN_FILEPOS INT_FAST64_MIN
 #else
 typedef int_fast32_t filepos_t;
 #define MAX_FILEPOS INT_FAST32_MAX
+#define MIN_FILEPOS INT_FAST32_MIN
 #endif
 
 #define INVALID_FILEPOS_T  ((filepos_t)-1)

--- a/libebml2/ebmlmaster.c
+++ b/libebml2/ebmlmaster.c
@@ -277,12 +277,12 @@ static err_t ReadData(ebml_master *Element, struct stream *Input, const ebml_par
 {
     int UpperEltFound = 0;
     bool_t bFirst = 1;
-    ebml_element *SubElement;
+    ebml_element *SubElement = NULL;
     ebml_crc *CRCElement = NULL;
     struct stream *ReadStream = Input;
     array CrcBuffer;
     uint8_t *CRCData = NULL;
-    size_t CRCDataSize;
+    size_t CRCDataSize = 0;
 
     // remove all existing elements, including the mandatory ones...
     NodeTree_Clear((nodetree*)Element);

--- a/mkclean/mkclean.c
+++ b/mkclean/mkclean.c
@@ -2526,6 +2526,7 @@ int main(int argc, const char *argv[])
 
                         if (MATROSKA_BlockGetFrameCount(pBlockInfo->Block))
                         {
+                            RemuxErr = ERR_NONE;
                             block_info *prevBlock = NULL;
                             if (ARRAYCOUNT(Alternate3DTracks, block_info*) && ARRAYBEGIN(Alternate3DTracks, block_info*)[*pTrackOrder])
                             {

--- a/mkclean/mkclean.c
+++ b/mkclean/mkclean.c
@@ -749,7 +749,7 @@ static bool_t GenerateCueEntries(ebml_master *Cues, array *Clusters, ebml_master
     matroska_block *Block;
     ebml_element **Cluster;
     matroska_cuepoint *CuePoint;
-    int64_t TrackNum;
+    int64_t TrackNum = INT64_MAX;
     mkv_timestamp_t PrevTimestamp = INVALID_TIMESTAMP_T, BlockTimestamp;
 
     Track = GetMainTrack(Tracks, NULL);

--- a/mkclean/mkclean.c
+++ b/mkclean/mkclean.c
@@ -1409,7 +1409,7 @@ int main(int argc, const char *argv[])
     ebml_parser_context RContext;
     ebml_parser_context RSegmentContext;
     int UpperElement;
-    filepos_t MetaSeekBefore, MetaSeekAfter;
+    filepos_t MetaSeekBefore = 0, MetaSeekAfter;
     filepos_t NextPos = 0, SegmentSize = 0, ClusterSize, CuesSize = MIN_FILEPOS;
     size_t ExtraVoidSize = 0;
     mkv_timestamp_t PrevTimestamp;

--- a/mkclean/mkclean.c
+++ b/mkclean/mkclean.c
@@ -1410,7 +1410,7 @@ int main(int argc, const char *argv[])
     ebml_parser_context RSegmentContext;
     int UpperElement;
     filepos_t MetaSeekBefore, MetaSeekAfter;
-    filepos_t NextPos = 0, SegmentSize = 0, ClusterSize, CuesSize;
+    filepos_t NextPos = 0, SegmentSize = 0, ClusterSize, CuesSize = MIN_FILEPOS;
     size_t ExtraVoidSize = 0;
     mkv_timestamp_t PrevTimestamp;
     bool_t CuesChanged;


### PR DESCRIPTION
Some are legit, some are MSVC bogus complains.