### PR TITLE
libmatroska2: 0 duration frames can be keyframes

### DIFF
--- a/libmatroska2/matroskamain.c
+++ b/libmatroska2/matroskamain.c
@@ -698,7 +698,6 @@ uint16_t MATROSKA_BlockTrackNum(const matroska_block *Block)
 bool_t MATROSKA_BlockKeyframe(const matroska_block *Block)
 {
     ebml_master *BlockGroup;
-    ebml_integer *Duration;
 
     assert(Node_IsPartOf(Block,MATROSKA_BLOCK_CLASS));
     if (Block->IsKeyframe)
@@ -711,14 +710,7 @@ bool_t MATROSKA_BlockKeyframe(const matroska_block *Block)
     if (!BlockGroup || !Node_IsPartOf(BlockGroup,MATROSKA_BLOCKGROUP_CLASS))
         return 0;
 
-    if (EBML_MasterFindChild(BlockGroup,MATROSKA_getContextReferenceBlock()))
-        return 0;
-
-    Duration = (ebml_integer*)EBML_MasterFindChild(BlockGroup,MATROSKA_getContextBlockDuration());
-    if (Duration!=NULL && EBML_IntegerValue(Duration)==0)
-        return 0;
-
-    return 1;
+    return EBML_MasterFindChild(BlockGroup,MATROSKA_getContextReferenceBlock()) == NULL;
 }
 
 bool_t MATROSKA_BlockDiscardable(const matroska_block *Block)


### PR DESCRIPTION
The part of the Matroska specifications that claimed that Blocks from a BlockGroup with duration zero are no keyframes has been dropped in [9313a00f7391a285f95e9d6f0a5f8f3f80ed4779](https://github.com/ietf-wg-cellar/matroska-specification/pull/207). This commit brings libmatroska2 in line with this change.

The earlier version e.g. made mkvalidator warn about files muxed by FFmpeg that contained pgs subtitles (which are muxed as zero-duration subtitles, which is spec-compliant).

rebased version of #40