### PR TITLE
libebml2: fix misc. leaks

### DIFF
--- a/libebml2/ebmlmaster.c
+++ b/libebml2/ebmlmaster.c
@@ -405,6 +405,7 @@ processCrc:
     if (CRCData!=NULL)
     {
         Element->CheckSumStatus = EBML_CRCMatches(CRCElement, CRCData, CRCDataSize)?2:1;
+        NodeDelete((node*)CRCElement);
         if (CRCData == ARRAYBEGIN(CrcBuffer,uint8_t))
         {
             StreamClose(ReadStream);

--- a/libebml2/ebmlmaster.c
+++ b/libebml2/ebmlmaster.c
@@ -356,6 +356,7 @@ static err_t ReadData(ebml_master *Element, struct stream *Input, const ebml_par
                                         Stream_Seek(Input,EBML_ElementPositionEnd(SubElement),SEEK_SET);
                                         if (Stream_Read(Input, CRCData, CRCDataSize, NULL)!=ERR_NONE)
                                         {
+                                            StreamClose(ReadStream);
                                             ReadStream=Input; // revert back to normal reading
                                             ArrayClear(&CrcBuffer);
                                         }

--- a/libebml2/ebmlmaster.c
+++ b/libebml2/ebmlmaster.c
@@ -418,6 +418,7 @@ processCrc:
     {
         assert(SubElement!=NULL);
         Stream_Seek(Input,SubElement->ElementPosition,SEEK_SET);
+        NodeDelete((node*)SubElement); // forget about it, it will be read again later
     }
     return ERR_NONE;
 }


### PR DESCRIPTION
Caught by the `CONFIG_DEBUG_LEAKS` compiler option.