### PR TITLE
corec: use uppercase min/max macros to avoid clash with Windows ones

### DIFF
--- a/corec/corec/helper.h
+++ b/corec/corec/helper.h
@@ -60,13 +60,12 @@ typedef int32_t datetime_t;
 
 #define INVALID_DATETIME_T  0
 
-// stdlib.h needs to be included first
-#if !defined(min) && !defined(NOMINMAX)
-#  define min(x,y)  ((x)>(y)?(y):(x))
+#if !defined(MIN)
+#  define MIN(x,y)  ((x)>(y)?(y):(x))
 #endif
 
-#if !defined(max) && !defined(NOMINMAX)
-#  define max(x,y)  ((x)<(y)?(y):(x))
+#if !defined(MAX)
+#  define MAX(x,y)  ((x)<(y)?(y):(x))
 #endif
 
 

--- a/corec/corec/helpers/charconvert/charconvert_linux.c
+++ b/corec/corec/helpers/charconvert/charconvert_linux.c
@@ -38,7 +38,7 @@ void CharConvSS(charconv* CC, char* Out, size_t OutLen, const char* In)
         if (!CC || !_InLen || iconv((iconv_t)CC, &_In, &_InLen, &_Out, &_OutLen) == (size_t)-1 ||
              iconv((iconv_t)CC, NULL, NULL, &_Out, &_OutLen) == (size_t)-1)
         {
-            size_t n = min(strlen(In),OutLen-1);
+            size_t n = MIN(strlen(In),OutLen-1);
             memcpy(Out,In,n*sizeof(char));
             Out[n] = 0;
             if (CC && _InLen)
@@ -152,7 +152,7 @@ void CharConvWW(charconv* CC, wchar_t* Out, size_t OutLen, const wchar_t* In)
         if (!CC || !_InLen || iconv((iconv_t)CC, &_In, &_InLen, &_Out, &_OutLen) == (size_t)-1 ||
                 iconv((iconv_t)CC, NULL, NULL, &_Out, &_OutLen) == (size_t)-1)
         {
-            size_t n = min(wcslen(In),OutLen-1);
+            size_t n = MIN(wcslen(In),OutLen-1);
             memcpy(Out,In,n*sizeof(wchar_t));
             Out[n] = 0;
                 if (CC && _InLen) iconv((iconv_t)CC, NULL, NULL, NULL, NULL); // reset state

--- a/corec/corec/helpers/charconvert/charconvert_osx.c
+++ b/corec/corec/helpers/charconvert/charconvert_osx.c
@@ -56,7 +56,7 @@ void CharConvSS(charconv* Conv, char* Out, size_t OutLen, const char* In)
         }
         else
         {
-            size_t n = min(In?strlen(In):0,OutLen-1);
+            size_t n = MIN(In?strlen(In):0,OutLen-1);
             memcpy(Out,In,n*sizeof(char));
             Out[n] = 0;
         }

--- a/corec/corec/helpers/charconvert/charconvert_utf8.c
+++ b/corec/corec/helpers/charconvert/charconvert_utf8.c
@@ -337,7 +337,7 @@ void CharConvSS(charconv* CC, char* Out, size_t OutLen, const char* In)
         }
         else
         {
-	        size_t n = min(strlen(In),OutLen-1);
+	        size_t n = MIN(strlen(In),OutLen-1);
 	        memcpy(Out,In,n*sizeof(char));
 	        Out[n] = 0;
         }

--- a/corec/corec/helpers/charconvert/charconvert_win32.c
+++ b/corec/corec/helpers/charconvert/charconvert_win32.c
@@ -36,7 +36,7 @@ void CharConvSS(charconv* CC, char* Out, size_t OutLen, const char* In)
 			!MultiByteToWideChar(InCode,0,In,-1,Temp,512) ||
 			!WideCharToMultiByte(OutCode,0,Temp,-1,Out,(int)OutLen,0,0))
 		{
-			size_t n = min(strlen(In),OutLen-1);
+			size_t n = MIN(strlen(In),OutLen-1);
 			memcpy(Out,In,n*sizeof(char));
 			Out[n] = 0;
 		}
@@ -72,7 +72,7 @@ void CharConvWW(charconv* UNUSED_PARAM(CC), wchar_t* Out, size_t OutLen, const w
 #else
 	if (OutLen>0)
 	{
-		size_t n = min(wcslen(In),OutLen-1);
+		size_t n = MIN(wcslen(In),OutLen-1);
 		memcpy(Out,In,n*sizeof(wchar_t));
 		Out[n] = 0;
 	}

--- a/corec/corec/helpers/file/file_win32.c
+++ b/corec/corec/helpers/file/file_win32.c
@@ -395,7 +395,7 @@ static bool_t FileRecycle(const tchar_t* Path)
 
     memset(&DelStruct,0,sizeof(DelStruct));
     DelStruct.wFunc = FO_DELETE;
-    l = min(tcslen(Path)+1,TSIZEOF(PathEnded)-1);
+    l = MIN(tcslen(Path)+1,TSIZEOF(PathEnded)-1);
     tcscpy_s(PathEnded,TSIZEOF(PathEnded),Path);
     PathEnded[l]=0;
     DelStruct.pFrom = PathEnded;

--- a/corec/corec/helpers/file/streams.c
+++ b/corec/corec/helpers/file/streams.c
@@ -17,7 +17,7 @@ static err_t DummySkip(void* p, intptr_t* Skip)
     err_t Err = ERR_NONE;
     while (n>0 && Err == ERR_NONE)
     {
-        Err = Stream_Read(p,Buf,min(n,(intptr_t)sizeof(Buf)),&Readed);
+        Err = Stream_Read(p,Buf,MIN(n,(intptr_t)sizeof(Buf)),&Readed);
         n -= Readed;
     }
     *Skip = n;

--- a/corec/corec/node/node.c
+++ b/corec/corec/node/node.c
@@ -778,7 +778,7 @@ static void MetaConst(const nodemeta* i,void* Data)
     else
     {
         memset((uint8_t*)Data+i->Id,0,Size);
-        memcpy((uint8_t*)Data+i->Id,&i->Data,min(sizeof(uintptr_t),Size));
+        memcpy((uint8_t*)Data+i->Id,&i->Data,MIN(sizeof(uintptr_t),Size));
     }
 }
 
@@ -1164,7 +1164,7 @@ static void InitClass(nodecontext* p,nodeclass* Class)
             assert(NodeClass_Context(Parent) == NodeClass_Context(Class));
 
             ClassId = NodeClass_ClassId(Class);
-            memcpy(Class+1,Parent+1,min(Class->VMTSize,Parent->VMTSize));
+            memcpy(Class+1,Parent+1,MIN(Class->VMTSize,Parent->VMTSize));
             NodeClass_ClassId(Class) = ClassId;
         }
 

--- a/corec/corec/str/str.c
+++ b/corec/corec/str/str.c
@@ -96,7 +96,7 @@ tchar_t* tcscpy_s(tchar_t* Out,size_t OutLen,const tchar_t* In)
     assert(In != NULL);
 	if (OutLen>0)
 	{
-		size_t n = min(tcslen(In),OutLen-1);
+		size_t n = MIN(tcslen(In),OutLen-1);
 		memcpy(Out,In,n*sizeof(tchar_t));
 		Out[n] = 0;
 	}
@@ -108,7 +108,7 @@ tchar_t* tcsncpy_s(tchar_t* Out,size_t OutLen,const tchar_t* In,size_t n)
     assert(In != NULL);
 	if (OutLen>0)
 	{
-		n = min(min(tcslen(In),n),OutLen-1);
+		n = MIN(MIN(tcslen(In),n),OutLen-1);
 		memcpy(Out,In,n*sizeof(tchar_t));
 		Out[n] = 0;
 	}
@@ -180,7 +180,7 @@ static int get_decimals(int Decimals, int64_t IntValue)
         TmpVal *= 10;
         Result++;
     }
-    return min(Decimals,Result);
+    return MIN(Decimals,Result);
 }
 
 void vstprintf_s(tchar_t* Out,size_t OutLen,const tchar_t* Mask,va_list Arg)
@@ -360,7 +360,7 @@ void vstprintf_s(tchar_t* Out,size_t OutLen,const tchar_t* Mask,va_list Arg)
 				In = va_arg(Arg,const tchar_t*);
                 if (In)
                 {
-				    n = min(tcslen(In),OutLen-1);
+				    n = MIN(tcslen(In),OutLen-1);
 				    Width -= n;
 				    if (!AlignLeft)
 					    while (--Width>=0 && OutLen>1)
@@ -380,7 +380,7 @@ void vstprintf_s(tchar_t* Out,size_t OutLen,const tchar_t* Mask,va_list Arg)
 				break;
 			case 'S':
 				InA = va_arg(Arg,const char*);
-				n = min(strlen(InA),OutLen-1);
+				n = MIN(strlen(InA),OutLen-1);
 				Width -= n;
 				if (!AlignLeft)
 					while (--Width>=0 && OutLen>1)
@@ -429,7 +429,7 @@ void vstprintf_s(tchar_t* Out,size_t OutLen,const tchar_t* Mask,va_list Arg)
                         }
 
                         if (Decimals>0)
-                            max_decimal_digits = max(Decimals,(int)w);
+                            max_decimal_digits = MAX(Decimals,(int)w);
                         else
                             max_decimal_digits = w;
 
@@ -495,7 +495,7 @@ void vstprintf_s(tchar_t* Out,size_t OutLen,const tchar_t* Mask,va_list Arg)
                     }
 
                     if (*Mask==T('f') && w)
-                        w = max(w,6);
+                        w = MAX(w,6);
                     if (w && OutLen>1)
                     {
                         *Out++ = T('.');

--- a/corec/corec/str/str_win32.c
+++ b/corec/corec/str/str_win32.c
@@ -31,7 +31,7 @@ int tcsicmp(const tchar_t* a,const tchar_t* b)
 
 int tcsnicmp(const tchar_t* a,const tchar_t* b,size_t n)
 {
-    int i = CompareString(LOCALE_USER_DEFAULT,NORM_IGNORECASE,a,min(tcslen(a),n),b,min(tcslen(b),n));
+    int i = CompareString(LOCALE_USER_DEFAULT,NORM_IGNORECASE,a,MIN(tcslen(a),n),b,MIN(tcslen(b),n));
     if (i)
         return i-CSTR_EQUAL;
 
@@ -59,7 +59,7 @@ int tcscmp(const tchar_t* a,const tchar_t* b)
 
 int tcsncmp(const tchar_t* a,const tchar_t* b,size_t n)
 {
-    int i = CompareString(LOCALE_USER_DEFAULT,0,a,min(tcslen(a),n),b,min(tcslen(b),n));
+    int i = CompareString(LOCALE_USER_DEFAULT,0,a,MIN(tcslen(a),n),b,MIN(tcslen(b),n));
     if (i)
         return i-CSTR_EQUAL;
 

--- a/libebml2/ebmlnumber.c
+++ b/libebml2/ebmlnumber.c
@@ -225,7 +225,7 @@ static err_t ReadDataFloat(ebml_float *Element, struct stream *Input, const ebml
         goto failed;
     }
 
-    Result = Stream_Read(Input,Value,min((size_t)Element->Base.DataSize,sizeof(Value)),NULL); // min is for code safety
+    Result = Stream_Read(Input,Value,MIN((size_t)Element->Base.DataSize,sizeof(Value)),NULL); // min is for code safety
     if (Result != ERR_NONE)
         goto failed;
 

--- a/libebml2/ebmlvoid.c
+++ b/libebml2/ebmlvoid.c
@@ -26,9 +26,9 @@ static err_t RenderData(ebml_element *Element, struct stream *Output, bool_t bFo
     memset(Buf,0,sizeof(Buf));
     while (Err==ERR_NONE && Left)
     {
-        Err = Stream_Write(Output,Buf,min(Left,sizeof(Buf)),&Written);
+        Err = Stream_Write(Output,Buf,MIN(Left,sizeof(Buf)),&Written);
         if (Err == ERR_NONE)
-            Left -= min(Left,sizeof(Buf));
+            Left -= MIN(Left,sizeof(Buf));
     }
     if (Rendered)
         *Rendered = Element->DataSize - Left;

--- a/libmatroska2/matroskamain.c
+++ b/libmatroska2/matroskamain.c
@@ -212,7 +212,7 @@ err_t CompressFrameZLib(const uint8_t *Cursor, size_t CursorSize, uint8_t **OutB
 
     if (OutBuf && OutSize)
         // TODO: write directly in the output buffer
-        memcpy(*OutBuf, ARRAYBEGIN(TmpBuf,uint8_t), min(*OutSize, stream.total_out));
+        memcpy(*OutBuf, ARRAYBEGIN(TmpBuf,uint8_t), MIN(*OutSize, stream.total_out));
     ArrayClear(&TmpBuf);
 
     if (OutSize)
@@ -1076,7 +1076,7 @@ err_t MATROSKA_BlockReadData(matroska_block *Element, struct stream *Input, int 
                                 Err = ERR_INVALID_DATA;
                             else
                             {
-                                lzo_uint outSize = max(2048, ARRAYBEGIN(Element->SizeList,int32_t)[0] << 2);
+                                lzo_uint outSize = MAX(2048, ARRAYBEGIN(Element->SizeList,int32_t)[0] << 2);
                                 if (!ArrayResize(&Element->Data, outSize, 0))
                                     Err = ERR_OUT_OF_MEMORY;
                                 else
@@ -1220,7 +1220,7 @@ err_t MATROSKA_BlockReadData(matroska_block *Element, struct stream *Input, int 
                             Err = ERR_INVALID_DATA;
                         else
                         {
-                            lzo_uint outSize = max(2048, ARRAYBEGIN(Element->SizeList,int32_t)[NumFrame] << 2);
+                            lzo_uint outSize = MAX(2048, ARRAYBEGIN(Element->SizeList,int32_t)[NumFrame] << 2);
                             if (!ArrayResize(&Element->Data, OutSize + outSize, 0))
                                 Err = ERR_OUT_OF_MEMORY;
                             else

--- a/mkclean/mkclean.c
+++ b/mkclean/mkclean.c
@@ -1927,7 +1927,7 @@ int main(int argc, const char *argv[])
         {
             Elt2 = EBML_MasterFindChild((ebml_master*)Elt,MATROSKA_getContextTrackNumber());
             if (Elt2)
-                i = max(i,(int)EBML_IntegerValue((ebml_integer*)Elt2));
+                i = MAX(i,(int)EBML_IntegerValue((ebml_integer*)Elt2));
         }
         ArrayResize(&WTracks,sizeof(track_info)*(i+1),0);
         ArrayZero(&WTracks);

--- a/mkparts/mkparts.c
+++ b/mkparts/mkparts.c
@@ -130,7 +130,7 @@ static void CopyTo(struct stream *Input, struct stream *Output, filepos_t StartP
     Stream_Seek(Input, StartPos, SEEK_SET);
     while (SizeToCopy)
     {
-        Err = Stream_ReadOneOrMore(Input, Data, min(SizeToCopy, (filepos_t)sizeof(Data)), &readSize);
+        Err = Stream_ReadOneOrMore(Input, Data, MIN(SizeToCopy, (filepos_t)sizeof(Data)), &readSize);
         if (Err==ERR_NONE || Err == ERR_NEED_MORE_DATA)
         {
             if (!Quiet) TextWrite(StdErr,T("."));

--- a/mkvalidator/mkvalidator.c
+++ b/mkvalidator/mkvalidator.c
@@ -1149,7 +1149,7 @@ int main(int argc, const char *argv[])
                         assert(EbmlDocVer!=NULL);
                         if (EbmlDocVer)
                         {
-                            TrackMax = max(TrackMax,(size_t)EL_Int(EbmlDocVer));
+                            TrackMax = MAX(TrackMax,(size_t)EL_Int(EbmlDocVer));
                             ARRAYBEGIN(Tracks,track_info)[TrackCount].Num = (int)EL_Int(EbmlDocVer);
                         }
                         EbmlDocVer = EBML_MasterFindChild(Elt,MATROSKA_getContextTrackType());


### PR DESCRIPTION
They can be found in sys/param.h on some system.