### PR TITLE
corec: check/fix pointer alignment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ if(DEV_MODE)
   set(CMAKE_C_EXTENSIONS OFF)
   add_c_flag_if_supported(-Wno-error=unused-command-line-argument
                           -Wall -Wextra -Wpedantic -Wfatal-errors -fstack-protector-strong
+                          -Wcast-align
                           -Werror=missing-field-initializers
                           -Werror=excess-initializers
                           -Werror=strict-aliasing

--- a/corec/corec/array/array.c
+++ b/corec/corec/array/array.c
@@ -94,12 +94,12 @@ static NOINLINE bool_t Data_ReAlloc(array *a,size_t n)
         }
         else
         {
-            datahead* Head;
+            datahead* Head = NULL;
             if (Data_IsHeap(hp))
             {
                 Head = realloc(hp,n+sizeof(datahead));
             }
-            else
+            if (!Head)
             {
                 Head = malloc(n+sizeof(datahead));
                 if (Head)

--- a/corec/corec/array/array.c
+++ b/corec/corec/array/array.c
@@ -65,7 +65,7 @@ static NOINLINE bool_t Data_ReAlloc(array *a,size_t n)
             return 0;
 
         Head->Size = n|DATA_FLAG_HEAP;
-        a->_Begin = &Head->data;
+        a->_Begin = Head->data;
         return 1;
     }
 
@@ -103,7 +103,10 @@ static NOINLINE bool_t Data_ReAlloc(array *a,size_t n)
             {
                 Head = malloc(n+sizeof(datahead));
                 if (Head)
-                    memcpy(&Head->data,a->_Begin,oldsize);
+                {
+                    memcpy(Head->data,a->_Begin,oldsize);
+                    free(hp);
+                }
             }
 
             if (!Head)

--- a/corec/corec/array/array.c
+++ b/corec/corec/array/array.c
@@ -350,9 +350,9 @@ static void SlowSort(array* p, size_t Count, size_t Width, arraycmp Cmp, const v
 #else
     uint8_t Tmp[Width];
 #endif
-    uint8_t* End = ARRAYBEGIN(*p,uint8_t) + Count*Width;
-    uint8_t* i;
-    uint8_t* j;
+    char* End = ARRAYBEGIN(*p,char) + Count*Width;
+    char* i;
+    char* j;
 
     j = p->_Begin;
     for (i=j+Width; i!=End; i+=Width)
@@ -387,7 +387,7 @@ static void SlowSort(array* p, size_t Count, size_t Width, arraycmp Cmp, const v
                 memcpy(j,i,Width);
             }
         }
-        p->_Used = j - (uint8_t*)p->_Begin + Width;
+        p->_Used = j - p->_Begin + Width;
     }
 }
 
@@ -488,7 +488,7 @@ intptr_t ArrayFindEx(const array* p, size_t Count, size_t Width, const void* Dat
     else
     {
         intptr_t No = 0;
-        const uint8_t* i;
+        const char* i;
         for (i=p->_Begin;Count--;i+=Width,++No)
             if (memcmp(i,Data,Width)==0)
             {

--- a/corec/corec/array/array.h
+++ b/corec/corec/array/array.h
@@ -27,7 +27,7 @@ typedef struct cc_memheap cc_memheap;
 typedef struct array
 {
 	// these are private members, use ARRAY macros to access them
-	void* _Begin;
+	char* _Begin;
 	size_t _Used;
 
 } array;
@@ -61,7 +61,7 @@ ARRAY_DLL void ArrayDelete(array* p, size_t Ofs,  size_t Length);
 #define ArraySort(p,type,Cmp,CmpParam,Unique)     ArraySortEx(p,ARRAYCOUNT(*p,type),sizeof(type),Cmp,CmpParam,Unique)
 
 #ifdef CONFIG_DEBUGCHECKS
-#define ARRAYBEGIN(Array,Type)		(assert(&(Array)!=NULL),(Type*)((Array)._Begin))
+#define ARRAYBEGIN(Array,Type)		(assert(&(Array)!=NULL),(Type*)(void*)((Array)._Begin))
 #define ARRAYEMPTY(Array)			(assert(&(Array)!=NULL),(Array)._Used==0)
 #define ARRAYCOUNT(Array,Type)		(assert(&(Array)!=NULL),(((Array)._Used))/sizeof(Type))
 #else

--- a/corec/corec/memheap.h
+++ b/corec/corec/memheap.h
@@ -24,7 +24,7 @@ typedef void (*memheap_write)(const void* This,void*,const void* Src,size_t Pos,
 
 #define ARRAY_POINTER_HOLDER \
         size_t Size; \
-        alignas(max_align_t) uint8_t data[]
+        alignas(max_align_t) char data[]
 
 // we can't use a type with a flexible array inside another structure, so we
 // use the same define everywhere

--- a/mkclean/mkclean.c
+++ b/mkclean/mkclean.c
@@ -119,7 +119,7 @@ typedef struct block_info
 
 } block_info;
 
-#define TABLE_MARKER (uint8_t*)1
+#define TABLE_MARKER (void*)(uintptr_t)1
 
 typedef struct track_info
 {


### PR DESCRIPTION
Let the compiler detect suspicious casts.