### PR TITLE
spectool: update/clean the semantic outputs based on RFC 9559

### DIFF
--- a/libmatroska2/matroska2/matroska_sem.h
+++ b/libmatroska2/matroska2/matroska_sem.h
@@ -321,18 +321,17 @@ MATROSKA_DLL const ebml_context *MATROSKA_getContextTags(void);
 MATROSKA_DLL const ebml_context *MATROSKA_getContextSegment(void);
 
 /**
- *The `TrackType` defines the type of each frame found in the `Track`.
-The value **SHOULD** be stored on 1 octet.
+ *The TrackType defines the type of each frame found in the Track. The value **SHOULD** be stored on 1 octet.
  */
 typedef enum {
   MATROSKA_TRACK_TYPE_VIDEO            = 0x1, // An image.
   MATROSKA_TRACK_TYPE_AUDIO            = 0x2, // Audio samples.
-  MATROSKA_TRACK_TYPE_COMPLEX          = 0x3, // A mix of different other `TrackType`. The codec needs to define how the `Matroska Player` should interpret such data.
+  MATROSKA_TRACK_TYPE_COMPLEX          = 0x3, // A mix of different other TrackType. The codec needs to define how the Matroska Player should interpret such data.
   MATROSKA_TRACK_TYPE_LOGO             = 0x10, // An image to be rendered over the video track(s).
   MATROSKA_TRACK_TYPE_SUBTITLE         = 0x11, // Subtitle or closed caption data to be rendered over the video track(s).
   MATROSKA_TRACK_TYPE_BUTTONS          = 0x12, // Interactive button(s) to be rendered over the video track(s).
-  MATROSKA_TRACK_TYPE_CONTROL          = 0x20, // Metadata used to control the player of the `Matroska Player`.
-  MATROSKA_TRACK_TYPE_METADATA         = 0x21, // Timed metadata that can be passed on to the `Matroska Player`.
+  MATROSKA_TRACK_TYPE_CONTROL          = 0x20, // Metadata used to control the player of the Matroska Player.
+  MATROSKA_TRACK_TYPE_METADATA         = 0x21, // Timed metadata that can be passed on to the Matroska Player.
 } MatroskaTrackType;
 
 /**
@@ -343,7 +342,7 @@ typedef enum {
   MATROSKA_TRACK_ENCODING_COMP_ZLIB             = 0, // zlib compression (RFC1950).
   MATROSKA_TRACK_ENCODING_COMP_BZLIB            = 1, // bzip2 compression (BZIP2) **SHOULD NOT** be used.
   MATROSKA_TRACK_ENCODING_COMP_LZO1X            = 2, // Lempel-Ziv-Oberhumer compression (LZO) **SHOULD NOT** be used.
-  MATROSKA_TRACK_ENCODING_COMP_HEADERSTRIP      = 3, // Octets in `ContentCompSettings` ((#contentcompsettings-element)) have been stripped from each frame.
+  MATROSKA_TRACK_ENCODING_COMP_HEADERSTRIP      = 3, // Octets in ContentCompSettings ((#contentcompsettings-element)) have been stripped from each frame.
 } MatroskaTrackEncodingCompAlgo;
 
 /**
@@ -389,18 +388,15 @@ typedef enum {
 } MatroskaVideoStereoMode;
 
 /**
- *Indicates whether the `BlockAdditional` element with `BlockAddID` of "1"
-    contains Alpha data as defined by the Codec Mapping for the `CodecID`.
- Undefined values (i.e., values other than 0 or 1) **SHOULD NOT** be used, as the
- behavior of known implementations is different.
+ *Indicates whether the BlockAdditional element with BlockAddID of "1"     contains Alpha data as defined by the Codec Mapping for the CodecID.  Undefined values (i.e., values other than 0 or 1) **SHOULD NOT** be used, as the  behavior of known implementations is different.
  */
 typedef enum {
-  MATROSKA_VIDEO_ALPHAMODE_NONE             = 0, // The `BlockAdditional` element with `BlockAddID` of "1" does not exist or **SHOULD NOT** be considered as containing such data.
-  MATROSKA_VIDEO_ALPHAMODE_PRESENT          = 1, // The `BlockAdditional` element with `BlockAddID` of "1" contains alpha channel data.
+  MATROSKA_VIDEO_ALPHAMODE_NONE             = 0, // The BlockAdditional element with BlockAddID of "1" does not exist or **SHOULD NOT** be considered as containing such data.
+  MATROSKA_VIDEO_ALPHAMODE_PRESENT          = 1, // The BlockAdditional element with BlockAddID of "1" contains alpha channel data.
 } MatroskaVideoAlphaMode;
 
 /**
- *Bogus `StereoMode` value used in old versions of [@?libmatroska].
+ *Bogus StereoMode value used in old versions of libmatroska.
  */
 typedef enum {
   MATROSKA_VIDEO_OLDSTEREOMODE_MONO             = 0,
@@ -410,7 +406,7 @@ typedef enum {
 } MatroskaVideoOldStereoMode;
 
 /**
- *How `DisplayWidth` and `DisplayHeight` are interpreted.
+ *How DisplayWidth and DisplayHeight are interpreted.
  */
 typedef enum {
   MATROSKA_DISPLAY_UNIT_PIXELS           = 0,
@@ -430,8 +426,7 @@ typedef enum {
 } MatroskaVideoAspectRatioType;
 
 /**
- *The Matrix Coefficients of the video used to derive luma and chroma values from red, green, and blue color primaries.
-For clarity, the value and meanings for `MatrixCoefficients` are adopted from Table 4 of [@!ITU-H.273].
+ *The Matrix Coefficients of the video used to derive luma and chroma values from red, green, and blue color primaries. For clarity, the value and meanings for MatrixCoefficients are adopted from Table 4 of ITU-H.273.
  */
 typedef enum {
   MATROSKA_VIDEO_MATRIXCOEFFICIENTS_IDENTITY         = 0,
@@ -480,8 +475,7 @@ typedef enum {
 } MatroskaVideoRange;
 
 /**
- *The transfer characteristics of the video. For clarity,
-the value and meanings for `TransferCharacteristics` are adopted from Table 3 of [@!ITU-H.273].
+ *The transfer characteristics of the video. For clarity, the value and meanings for TransferCharacteristics are adopted from Table 3 of ITU-H.273.
  */
 typedef enum {
   MATROSKA_TRANSFER_RESERVED         = 0,
@@ -506,8 +500,7 @@ typedef enum {
 } MatroskaVideoTransferCharacteristics;
 
 /**
- *The color primaries of the video. For clarity,
-the value and meanings for `Primaries` are adopted from Table 2 of [@!ITU-H.273].
+ *The color primaries of the video. For clarity, the value and meanings for Primaries are adopted from Table 2 of ITU-H.273.
  */
 typedef enum {
   MATROSKA_VIDEO_PRIMARIES_RESERVED         = 0,
@@ -569,8 +562,8 @@ typedef enum {
  */
 typedef enum {
   MATROSKA_CONTENTENCODINGSCOPE_BLOCK            = 0x1, // All frame contents, excluding lacing data.
-  MATROSKA_CONTENTENCODINGSCOPE_PRIVATE          = 0x2, // The track's `CodecPrivate` data.
-  MATROSKA_CONTENTENCODINGSCOPE_NEXT             = 0x4, // The next ContentEncoding (next `ContentEncodingOrder`; the data inside `ContentCompression` and/or `ContentEncryption`).
+  MATROSKA_CONTENTENCODINGSCOPE_PRIVATE          = 0x2, // The track's CodecPrivate data.
+  MATROSKA_CONTENTENCODINGSCOPE_NEXT             = 0x4, // The next ContentEncoding (next ContentEncodingOrder; the data inside ContentCompression and/or ContentEncryption).
 } MatroskaContentEncodingScope;
 
 /**
@@ -619,12 +612,7 @@ typedef enum {
 } MatroskaContentSigHashAlgo;
 
 /**
- *Indicates what type of content the `ChapterAtom` contains and might be skipped.
-    It can be used to automatically skip content based on the type.
-    If a `ChapterAtom` is inside a `ChapterAtom` that has a `ChapterSkipType` set, it
-    **MUST NOT** have a `ChapterSkipType` or have a `ChapterSkipType` with the same value as it's parent `ChapterAtom`.
-If the `ChapterAtom` doesn't contain a `ChapterTimeEnd`, the value of the `ChapterSkipType` is only valid until the next `ChapterAtom` with a `ChapterSkipType` value or the end of the file.
-    
+ *Indicates what type of content the ChapterAtom contains and might be skipped.     It can be used to automatically skip content based on the type.     If a ChapterAtom is inside a ChapterAtom that has a ChapterSkipType set, it     **MUST NOT** have a ChapterSkipType or have a ChapterSkipType with the same value as it's parent ChapterAtom. If the ChapterAtom doesn't contain a ChapterTimeEnd, the value of the ChapterSkipType is only valid until the next ChapterAtom with a ChapterSkipType value or the end of the file.     
  */
 typedef enum {
   MATROSKA_CHAPTERSKIPTYPE_NO_SKIPPING      = 0, // Content which should not be skipped.

--- a/spectool/schema_2_kaxsemantic_cpp.xsl
+++ b/spectool/schema_2_kaxsemantic_cpp.xsl
@@ -57,8 +57,8 @@ static constexpr const MatroskaProfile VERSION_WEBM_SINCE_V4 = {true, false, 4};
 static constexpr const MatroskaProfile VERSION_MATROSKA_UP_TO_V2 = {false, false, 0, 2};
 // available since version 1, 2 and 3 of Matroska but not WebM or DivX
 static constexpr const MatroskaProfile VERSION_MATROSKA_UP_TO_V3 = {false, false, 0, 3};
-// available since version 1, 2, 3 and 4 of Matroska and WebM but not DivX
-static constexpr const MatroskaProfile VERSION_WEBM_UP_TO_V4 = {true, false, 0, 4};
+// available since version 1, 2, 3 and 4 of Matroska but not WebM or DivX
+static constexpr const MatroskaProfile VERSION_MATROSKA_UP_TO_V4 = {false, false, 0, 4};
 <xsl:for-each select="ebml:element[not(starts-with(@path,'\EBML\'))]">
     <!-- sorting messes the detection of the previous element MATROSKA_VERSION state -->
     <!-- Maybe for each output we create we also create a counterpart call to check if the new MATROSKA_VERSION state that should be used -->
@@ -515,7 +515,7 @@ static constexpr const MatroskaProfile VERSION_WEBM_UP_TO_V4 = {true, false, 0, 
         <xsl:when test="$node/@minver='4' and not($node/@maxver) and ebml:extension[@webm='1'] and not(ebml:extension[@divx='1'])"><xsl:text>VERSION_WEBM_SINCE_V4</xsl:text></xsl:when>
         <xsl:when test="(not($node/@minver) or $node/@minver='0') and $node/@maxver='2' and not(ebml:extension[@webm='1']) and not(ebml:extension[@divx='1'])"><xsl:text>VERSION_MATROSKA_UP_TO_V2</xsl:text></xsl:when>
         <xsl:when test="(not($node/@minver) or $node/@minver='0') and $node/@maxver='3' and not(ebml:extension[@webm='1']) and not(ebml:extension[@divx='1'])"><xsl:text>VERSION_MATROSKA_UP_TO_V3</xsl:text></xsl:when>
-        <xsl:when test="(not($node/@minver) or $node/@minver='0') and $node/@maxver='4' and ebml:extension[@webm='1'] and not(ebml:extension[@divx='1'])"><xsl:text>VERSION_WEBM_UP_TO_V4</xsl:text></xsl:when>
+        <xsl:when test="(not($node/@minver) or $node/@minver='0') and $node/@maxver='4' and not(ebml:extension[@webm='1']) and not(ebml:extension[@divx='1'])"><xsl:text>VERSION_MATROSKA_UP_TO_V4</xsl:text></xsl:when>
         <xsl:otherwise>
             <xsl:text>MatroskaProfile(</xsl:text>
             <xsl:choose>

--- a/spectool/schema_2_kaxsemantic_cpp_1x.xsl
+++ b/spectool/schema_2_kaxsemantic_cpp_1x.xsl
@@ -365,6 +365,7 @@ namespace libmatroska {
     <xsl:if test="$node/@maxver='0'">
         <xsl:choose>
             <xsl:when test="ebml:extension[@divx='1']"><xsl:text> // DivX specific</xsl:text></xsl:when>
+            <xsl:when test="$node/@name='TrackOverlay'"/> <!-- ignore deprecation to avoid API/ABI change -->
             <xsl:otherwise><xsl:text> // not supported</xsl:text></xsl:otherwise>
         </xsl:choose>
     </xsl:if>
@@ -414,7 +415,7 @@ namespace libmatroska {
   <xsl:template name="output-blocked-render">
     <xsl:param name="node"/>
 
-    <xsl:if test="$node/@maxver='0' or $node/@maxver='1' or $node/@maxver='2' or $node/@maxver='3'">
+    <xsl:if test="($node/@maxver='0' or $node/@maxver='1' or $node/@maxver='2' or $node/@maxver='3') and ($node/@name!='TrackOverlay')">
         <xsl:text>&#10;filepos_t Kax</xsl:text>
         <xsl:choose>
             <xsl:when test="ebml:extension[@cppname]"><xsl:value-of select="ebml:extension[@cppname][1]/@cppname" /></xsl:when>

--- a/spectool/schema_2_kaxsemantic_h.xsl
+++ b/spectool/schema_2_kaxsemantic_h.xsl
@@ -104,8 +104,6 @@ namespace libmatroska {
         <xsl:text>)&#10;</xsl:text>
         <xsl:if test="@maxver='0' or @maxver='1' or @maxver='2' or @maxver='3'">
             <xsl:text>public:&#10;</xsl:text>
-        </xsl:if>
-        <xsl:if test="@maxver='0' or @maxver='1' or @maxver='2' or @maxver='3'">
             <xsl:text>  libebml::filepos_t RenderData(libebml::IOCallback &amp; output, bool bForceRender, const ShouldWrite &amp; writeFilter) override;&#10;</xsl:text>
         </xsl:if>
         <xsl:text>};&#10;</xsl:text>

--- a/spectool/schema_2_kaxsemantic_h.xsl
+++ b/spectool/schema_2_kaxsemantic_h.xsl
@@ -508,6 +508,11 @@ namespace libmatroska {
                 <xsl:with-param name="label" select="concat(substring-before($label, ' [@?'), ' ', substring-before(substring-after($label, ' [@?'), ']'), '', substring-after(substring-after($label, ' [@?'), ']'))"/>
             </xsl:call-template>
         </xsl:when>
+        <xsl:when test="contains($label,' `')">
+            <xsl:call-template name="cleanEnumDoc">
+                <xsl:with-param name="label" select="concat(substring-before($label, ' `'), ' ', substring-before(substring-after($label, ' `'), '`'), '', substring-after(substring-after($label, ' `'), '`'))"/>
+            </xsl:call-template>
+        </xsl:when>
         <xsl:otherwise>
             <xsl:value-of select="$label"/>
         </xsl:otherwise>
@@ -525,6 +530,11 @@ namespace libmatroska {
         <xsl:when test="contains($label,' [@?')">
             <xsl:call-template name="cleanEnumDoc">
                 <xsl:with-param name="label" select="concat(substring-before($label, ' [@?'), ' (', substring-before(substring-after($label, ' [@?'), ']'), ')', substring-after(substring-after($label, ' [@?'), ']'))"/>
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,' `')">
+            <xsl:call-template name="cleanEnumDoc">
+                <xsl:with-param name="label" select="concat(substring-before($label, ' `'), ' ', substring-before(substring-after($label, ' `'), '`'), '', substring-after(substring-after($label, ' `'), '`'))"/>
             </xsl:call-template>
         </xsl:when>
         <xsl:when test="contains($label,'; see usage notes')">

--- a/spectool/schema_2_kaxsemantic_h_1x.xsl
+++ b/spectool/schema_2_kaxsemantic_h_1x.xsl
@@ -522,6 +522,11 @@ namespace libmatroska {
                 <xsl:with-param name="label" select="concat(substring-before($label, ' [@?'), ' (', substring-before(substring-after($label, ' [@?'), ']'), ')', substring-after(substring-after($label, ' [@?'), ']'))"/>
             </xsl:call-template>
         </xsl:when>
+        <xsl:when test="contains($label,' `')">
+            <xsl:call-template name="cleanEnumDoc">
+                <xsl:with-param name="label" select="concat(substring-before($label, ' `'), ' ', substring-before(substring-after($label, ' `'), '`'), '', substring-after(substring-after($label, ' `'), '`'))"/>
+            </xsl:call-template>
+        </xsl:when>
         <xsl:when test="contains($label,'; see usage notes')">
             <xsl:call-template name="cleanEnumDoc">
                 <xsl:with-param name="label" select="concat(substring-before($label, '; see usage notes'), substring-after($label, '; see usage notes'))"/>
@@ -544,6 +549,11 @@ namespace libmatroska {
         <xsl:when test="contains($label,' [@?')">
             <xsl:call-template name="cleanEnumTitle">
                 <xsl:with-param name="label" select="concat(substring-before($label, ' [@?'), ' ', substring-before(substring-after($label, ' [@?'), ']'), '', substring-after(substring-after($label, ' [@?'), ']'))"/>
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,' `')">
+            <xsl:call-template name="cleanEnumDoc">
+                <xsl:with-param name="label" select="concat(substring-before($label, ' `'), ' ', substring-before(substring-after($label, ' `'), '`'), '', substring-after(substring-after($label, ' `'), '`'))"/>
             </xsl:call-template>
         </xsl:when>
         <xsl:otherwise>

--- a/spectool/schema_2_kaxsemantic_h_1x.xsl
+++ b/spectool/schema_2_kaxsemantic_h_1x.xsl
@@ -257,7 +257,9 @@ namespace libmatroska {
             </xsl:variable>
 
             <xsl:text>/**&#10; *</xsl:text>
-            <xsl:value-of select="ebml:documentation[@purpose='definition']"/>
+            <xsl:call-template name="cleanEnumTitle">
+                <xsl:with-param name="label" select="ebml:documentation[@purpose='definition']"/>
+            </xsl:call-template>
             <xsl:text>&#10; */&#10;</xsl:text>
             <xsl:text>typedef enum {&#10;</xsl:text>
 
@@ -527,6 +529,25 @@ namespace libmatroska {
         </xsl:when>
         <xsl:otherwise>
             <xsl:value-of select="translate($label, '&#10;', ' ')"/>
+        </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="cleanEnumTitle">
+    <xsl:param name="label"/>
+    <xsl:choose>
+        <xsl:when test="contains($label,' [@!')">
+            <xsl:call-template name="cleanEnumTitle">
+                <xsl:with-param name="label" select="concat(substring-before($label, ' [@!'), ' ', substring-before(substring-after($label, ' [@!'), ']'), '', substring-after(substring-after($label, ' [@!'), ']'))"/>
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,' [@?')">
+            <xsl:call-template name="cleanEnumTitle">
+                <xsl:with-param name="label" select="concat(substring-before($label, ' [@?'), ' ', substring-before(substring-after($label, ' [@?'), ']'), '', substring-after(substring-after($label, ' [@?'), ']'))"/>
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:value-of select="$label"/>
         </xsl:otherwise>
     </xsl:choose>
   </xsl:template>

--- a/spectool/schema_2_kaxsemantic_h_1x.xsl
+++ b/spectool/schema_2_kaxsemantic_h_1x.xsl
@@ -125,17 +125,17 @@ namespace libmatroska {
         </xsl:if>
         <xsl:if test="@maxver='0' or @maxver='1' or @maxver='2' or @maxver='3' or @length">
             <xsl:text>public:&#10;</xsl:text>
-        </xsl:if>
-        <xsl:if test="@maxver='0' or @maxver='1' or @maxver='2' or @maxver='3'">
-            <xsl:text>  filepos_t RenderData(IOCallback &amp; output, bool bForceRender, bool bSaveDefault) override;&#10;</xsl:text>
-        </xsl:if>
-        <xsl:if test="@length">
-            <xsl:text>  bool ValidateSize() const override {return IsFiniteSize() &amp;&amp; GetSize() </xsl:text>
-            <xsl:choose>
-                <xsl:when test="contains(@length, '=') or contains(@length, '&lt;') or contains(@length, '&gt;')"><xsl:value-of select="@length"/></xsl:when>
-                <xsl:otherwise><xsl:text>== </xsl:text><xsl:value-of select="@length"/></xsl:otherwise>
-            </xsl:choose>
-            <xsl:text>;}&#10;</xsl:text>
+            <xsl:if test="@maxver='0' or @maxver='1' or @maxver='2' or @maxver='3'">
+                <xsl:text>  filepos_t RenderData(IOCallback &amp; output, bool bForceRender, bool bSaveDefault) override;&#10;</xsl:text>
+            </xsl:if>
+            <xsl:if test="@length">
+                <xsl:text>  bool ValidateSize() const override {return IsFiniteSize() &amp;&amp; GetSize() </xsl:text>
+                <xsl:choose>
+                    <xsl:when test="contains(@length, '=') or contains(@length, '&lt;') or contains(@length, '&gt;')"><xsl:value-of select="@length"/></xsl:when>
+                    <xsl:otherwise><xsl:text>== </xsl:text><xsl:value-of select="@length"/></xsl:otherwise>
+                </xsl:choose>
+                <xsl:text>;}&#10;</xsl:text>
+            </xsl:if>
         </xsl:if>
         <xsl:text>};&#10;</xsl:text>
         <!-- <xsl:if test="$minVer &gt; 1 or ebml:extension[@divx='1']">#endif&#10;</xsl:if> -->

--- a/spectool/schema_2_kaxsemantic_h_1x.xsl
+++ b/spectool/schema_2_kaxsemantic_h_1x.xsl
@@ -123,7 +123,7 @@ namespace libmatroska {
             <xsl:text>  KaxSegmentUID(EBML_DEF_CONS EBML_DEF_SEP EBML_EXTRA_PARAM);&#10;</xsl:text>
             <xsl:text>#endif&#10;</xsl:text>
         </xsl:if>
-        <xsl:if test="@maxver='0' or @maxver='1' or @maxver='2' or @maxver='3' or @length">
+        <xsl:if test="(@maxver='0' or @maxver='1' or @maxver='2' or @maxver='3' or @length) and (@name!='TrackOverlay')">
             <xsl:text>public:&#10;</xsl:text>
             <xsl:if test="@maxver='0' or @maxver='1' or @maxver='2' or @maxver='3'">
                 <xsl:text>  filepos_t RenderData(IOCallback &amp; output, bool bForceRender, bool bSaveDefault) override;&#10;</xsl:text>

--- a/spectool/schema_2_matroska_sem_h.xsl
+++ b/spectool/schema_2_matroska_sem_h.xsl
@@ -419,6 +419,11 @@ void MATROSKA_InitSemantic(void);
                 <xsl:with-param name="label" select="concat(substring-before($label, '; see usage notes'), substring-after($label, '; see usage notes'))"/>
             </xsl:call-template>
         </xsl:when>
+        <xsl:when test="contains($label,' `')">
+            <xsl:call-template name="cleanEnumDoc">
+                <xsl:with-param name="label" select="concat(substring-before($label, ' `'), ' ', substring-before(substring-after($label, ' `'), '`'), '', substring-after(substring-after($label, ' `'), '`'))"/>
+            </xsl:call-template>
+        </xsl:when>
         <xsl:otherwise>
             <xsl:value-of select="translate($label, '&#10;', ' ')"/>
         </xsl:otherwise>
@@ -436,6 +441,11 @@ void MATROSKA_InitSemantic(void);
         <xsl:when test="contains($label,' [@?')">
             <xsl:call-template name="cleanEnumTitle">
                 <xsl:with-param name="label" select="concat(substring-before($label, ' [@?'), ' ', substring-before(substring-after($label, ' [@?'), ']'), '', substring-after(substring-after($label, ' [@?'), ']'))"/>
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,' `')">
+            <xsl:call-template name="cleanEnumDoc">
+                <xsl:with-param name="label" select="concat(substring-before($label, ' `'), ' ', substring-before(substring-after($label, ' `'), '`'), '', substring-after(substring-after($label, ' `'), '`'))"/>
             </xsl:call-template>
         </xsl:when>
         <xsl:otherwise>

--- a/spectool/schema_2_matroska_sem_h.xsl
+++ b/spectool/schema_2_matroska_sem_h.xsl
@@ -149,7 +149,9 @@ void MATROSKA_InitSemantic(void);
             </xsl:variable>
 
             <xsl:text>/**&#10; *</xsl:text>
-            <xsl:value-of select="ebml:documentation[@purpose='definition']"/>
+            <xsl:call-template name="cleanEnumTitle">
+                <xsl:with-param name="label" select="ebml:documentation[@purpose='definition']"/>
+            </xsl:call-template>
             <xsl:text>&#10; */&#10;</xsl:text>
             <xsl:text>typedef enum {&#10;</xsl:text>
 
@@ -419,6 +421,25 @@ void MATROSKA_InitSemantic(void);
         </xsl:when>
         <xsl:otherwise>
             <xsl:value-of select="translate($label, '&#10;', ' ')"/>
+        </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template name="cleanEnumTitle">
+    <xsl:param name="label"/>
+    <xsl:choose>
+        <xsl:when test="contains($label,' [@!')">
+            <xsl:call-template name="cleanEnumTitle">
+                <xsl:with-param name="label" select="concat(substring-before($label, ' [@!'), ' ', substring-before(substring-after($label, ' [@!'), ']'), '', substring-after(substring-after($label, ' [@!'), ']'))"/>
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:when test="contains($label,' [@?')">
+            <xsl:call-template name="cleanEnumTitle">
+                <xsl:with-param name="label" select="concat(substring-before($label, ' [@?'), ' ', substring-before(substring-after($label, ' [@?'), ']'), '', substring-after(substring-after($label, ' [@?'), ']'))"/>
+            </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise>
+            <xsl:value-of select="$label"/>
         </xsl:otherwise>
     </xsl:choose>
   </xsl:template>


### PR DESCRIPTION
Don't break the libmatroska 1.0 API/ABI (apart from some enums that were unused).